### PR TITLE
Fix python file detection in find_python_files_here

### DIFF
--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -168,7 +168,7 @@ update_helper_bash_functions() { if [ ! -f ~/.helper_bash_functions ]; then
 
 # python linters
 LINTER_MAX_LINE_LENGTH="140"
-find_python_files_here() { find . -type f | while read in ; do if file -i "${in}" | grep -q x-python ; then echo -n "${in} " ; fi ; done; }
+find_python_files_here() { find . -type f | while read in ; do if file -ib "${in}" | grep -q python ; then echo -n "${in} " ; fi ; done; }
 print_reinstall_warning() { echo -e "${Red}INFO: Just installed $1. Please re-run the last command to get the output and formatting that you're expecting.${Color_Off}"; }
 check_pylintrc() { if ! [ -f /tmp/pylintrc ]; then wget -O /tmp/pylintrc https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/pylintrc; fi; }
 check_apt_package() { if [[ $(dpkg -l | grep -w $1 | wc -l) -eq 0 ]]; then sudo apt update && sudo apt install -y $1; echo "installed"; fi; }


### PR DESCRIPTION
find_python_files_here wasn't always finding python files.
Sometimes file -i would return `x-script.python` instead of `x-python`
So, let's change the grep to match all python strings in MIME types
but, then if we had a txt file with python in the filename, we'd match that too
so, we add -b to tell type not to emit the filename, just the MIME type

Problem:
```
tom@tom-home:/tmp/er_interface/er_robot_config/src/er_robot_config$ find . -type f | while read in ; do if file -i "${in}" | grep -q x-python ; then echo -n "${in} " ; fi ; done
tom@tom-home:/tmp/er_interface/er_robot_config/src/er_robot_config$
```
Investigation:
```
tom@tom-home:/tmp/er_interface/er_robot_config/src/er_robot_config$ for x in $(!!); do echo $x; file -i $x; echo; done
for x in $(find . -type f); do echo $x; file -i $x; echo; done
./er_robot_config_utils.py
./er_robot_config_utils.py: text/x-script.python; charset=us-ascii

./er_srdf_collisions_cacher.py
./er_srdf_collisions_cacher.py: text/x-script.python; charset=us-ascii

./er_connectivity_checks.py
./er_connectivity_checks.py: text/x-script.python; charset=us-ascii

./er_load_setup_overrides.py
./er_load_setup_overrides.py: text/x-script.python; charset=us-ascii

./generate_robot_config.py
./generate_robot_config.py: text/x-script.python; charset=utf-8

./adapter_launch_utils.py
./adapter_launch_utils.py: text/x-script.python; charset=utf-8

./er_generate_frontend_config.py
./er_generate_frontend_config.py: text/x-script.python; charset=utf-8

./__init__.py
./__init__.py: inode/x-empty; charset=binary

./er_process_returned_frontend_config.py
./er_process_returned_frontend_config.py: text/x-script.python; charset=utf-8
```
Solution:
```
tom@tom-home:/tmp/er_interface/er_robot_config/src/er_robot_config$ find . -type f | while read in ; do if file -ib "${in}" | grep -q python ; then echo -n "${in} " ; fi ; done
./er_robot_config_utils.py ./er_srdf_collisions_cacher.py ./er_connectivity_checks.py ./er_load_setup_overrides.py ./generate_robot_config.py ./adapter_launch_utils.py ./er_generate_frontend_config.py ./er_process_returned_frontend_config.py
tom@tom-home:/tmp/er_interface/er_robot_config/src/er_robot_config$
```