### PR TITLE
Refactor Python file detection logic in script

### DIFF
--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -171,8 +171,8 @@ update_helper_bash_functions() { if [ ! -f ~/.helper_bash_functions ]; then
                                    echo -e "${Red}ERROR: Tried to replace this file but couldn't find it, something has gone wrong!${Color_Off}\n"
                                    return
                                  fi
-                                 if [ -f ${FIND_PYTHON_FILES_SCRIPT} ]; then
-                                   rm ${FIND_PYTHON_FILES_SCRIPT}
+                                 if [ -f "${FIND_PYTHON_FILES_SCRIPT}" ]; then
+                                   rm "${FIND_PYTHON_FILES_SCRIPT}"
                                  fi
                                  check_find_python_files
                                  wget -O ~/.helper_bash_functions ${THIS_SCRIPT_URL}

--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -147,6 +147,14 @@ function confirm() {
 			;;
 	esac
 }
+FIND_PYTHON_FILES_SCRIPT="$HOME/.find_python_files.sh"
+check_find_python_files() {
+  if ! [ -x "$FIND_PYTHON_FILES_SCRIPT" ]; then
+	  wget -qO "$FIND_PYTHON_FILES_SCRIPT" \
+		https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/find_python_files.sh
+	  chmod +x "$FIND_PYTHON_FILES_SCRIPT"
+  fi
+}
 alias cgrep="grep --color=always"
 ps_aux() { ps aux | cgrep $1 | grep -v grep ; }
 ps_aux_command() { ps -e -o command | cgrep $1 | grep -v grep ; }
@@ -163,12 +171,19 @@ update_helper_bash_functions() { if [ ! -f ~/.helper_bash_functions ]; then
                                    echo -e "${Red}ERROR: Tried to replace this file but couldn't find it, something has gone wrong!${Color_Off}\n"
                                    return
                                  fi
+                                 if [ -f ${FIND_PYTHON_FILES_SCRIPT} ]; then
+                                   rm ${FIND_PYTHON_FILES_SCRIPT}
+                                 fi
+                                 check_find_python_files
                                  wget -O ~/.helper_bash_functions ${THIS_SCRIPT_URL}
 }
 
 # python linters
 LINTER_MAX_LINE_LENGTH="140"
-find_python_files_here() { find . -type f | while read in ; do if file -ib "${in}" | grep -q python ; then echo -n "${in} " ; fi ; done; }
+find_python_files_here() {
+  check_find_python_files
+  "$FIND_PYTHON_FILES_SCRIPT"
+}
 print_reinstall_warning() { echo -e "${Red}INFO: Just installed $1. Please re-run the last command to get the output and formatting that you're expecting.${Color_Off}"; }
 check_pylintrc() { if ! [ -f /tmp/pylintrc ]; then wget -O /tmp/pylintrc https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/pylintrc; fi; }
 check_apt_package() { if [[ $(dpkg -l | grep -w $1 | wc -l) -eq 0 ]]; then sudo apt update && sudo apt install -y $1; echo "installed"; fi; }

--- a/find_python_files.sh
+++ b/find_python_files.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+#
+# find_python_files.sh
+#
+# Print Python source files at-or-below the current directory, one per
+# line, sorted and deduplicated. Shared by the local linter helper and
+# the CI workflow so both see the same set of files.
+#
+# DETECTION
+#   A file counts as Python if EITHER condition holds:
+#     - filename ends in .py or .pyi    (library modules, normal scripts)
+#     - `file -bi` reports a mime type containing "python" (driven
+#       internally by the file having a Python shebang on line 1, which
+#       is also the only way the kernel recognises it as Python — e.g.
+#       ROS nodes in scripts/ exec'd by name with no extension).
+#       libmagic emits either text/x-python or text/x-script.python
+#       depending on version, hence the substring match rather than an
+#       exact one (see Extend-Robotics/er_build_tools#37).
+#   Both rules are needed because they catch disjoint cases:
+#     - Library code under src/ has .py but no shebang (libraries are
+#       not meant to be directly executable), so mime-only would miss
+#       every src/ module — `file` reports them as text/plain since
+#       they have no shebang and Python has no magic number.
+#     - ROS nodes named like `scripts/my_node` have a shebang but no
+#       .py extension, so extension-only would miss them.
+#   The earlier `find_python_files_here` shipped only the mime check
+#   and so silently skipped every .py library file under src/. The
+#   extension check fixes that; the mime check covers the no-extension
+#   case.
+#
+# SCOPE
+#   Two modes, picked automatically:
+#
+#     git mode (cwd inside a git work tree, git installed):
+#       - uses `git ls-files` for enumeration
+#       - .gitignore is respected for free — no build/, devel/, .venv/,
+#         __pycache__/, generated stubs, project-specific ignores
+#       - .git/ is never traversed
+#       - tracked files only; untracked-but-intended Python is NOT
+#         returned. Switch to `git ls-files --others --exclude-standard
+#         --cached` if you need the staged-or-tracked set instead.
+#
+#     find mode (non-git dirs, or git missing/broken):
+#       - walks the filesystem from cwd
+#       - prunes the dirs listed in $EXCLUDE_DIRS below. The default
+#         list is intentionally minimal (only universally non-source
+#         dirs). Project-specific build/output/venv dirs (build/,
+#         devel/, .venv/, output/, .cache/, ...) are NOT excluded by
+#         default — operate in git mode to get .gitignore for free, or
+#         override EXCLUDE_DIRS for the run.
+#
+# OUTPUT
+#   - Paths relative to cwd, no `./` prefix, one per line, sorted.
+#   - No output and exit 0 when there are no Python files.
+#
+# NON-GOALS
+#   - .pyx (Cython) is intentionally not detected; pylint cannot lint it.
+#   - No content / style / blacklist filtering. Callers layer that on top
+#     (the CI workflow's BLACKLIST input does this).
+#
+
+# Directories pruned in find mode. Kept minimal — only dirs that are
+# never source under any convention. Project-specific dirs (build/,
+# devel/, .venv/, output/, ...) should be added per-project, or use
+# git mode (where .gitignore handles them for free).
+# Override at invocation:  EXCLUDE_DIRS='__pycache__ build' ./find_python_files.sh
+EXCLUDE_DIRS="${EXCLUDE_DIRS:-__pycache__}"
+
+# Print $1 to stdout iff it's a Python source file.
+#
+# `file` reports Python with either `text/x-python` or
+# `text/x-script.python` depending on libmagic version (see
+# Extend-Robotics/er_build_tools#37), so we grep for the substring
+# `python` in the mime line. `-b` strips the filename from the output
+# so a non-Python file whose name contains "python" doesn't slip in.
+emit_if_python() {
+    case "$1" in
+        *.py|*.pyi) printf '%s\n' "$1"; return 0 ;;
+    esac
+    if [ -f "$1" ] && file -bi "$1" 2>/dev/null | grep -q python; then
+        printf '%s\n' "$1"
+    fi
+}
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git ls-files | while IFS= read -r f; do
+        emit_if_python "$f"
+    done | sort -u
+else
+    # Build "! -path '*/X/*'" args from EXCLUDE_DIRS without eval.
+    set --
+    for dir in $EXCLUDE_DIRS; do
+        set -- "$@" '!' -path "*/$dir/*"
+    done
+    find . "$@" -type f | while IFS= read -r f; do
+        emit_if_python "${f#./}"
+    done | sort -u
+fi

--- a/find_python_files.sh
+++ b/find_python_files.sh
@@ -8,25 +8,23 @@
 #
 # DETECTION
 #   A file counts as Python if EITHER condition holds:
-#     - filename ends in .py or .pyi    (library modules, normal scripts)
-#     - `file -bi` reports a mime type containing "python" (driven
-#       internally by the file having a Python shebang on line 1, which
-#       is also the only way the kernel recognises it as Python — e.g.
-#       ROS nodes in scripts/ exec'd by name with no extension).
-#       libmagic emits either text/x-python or text/x-script.python
-#       depending on version, hence the substring match rather than an
-#       exact one (see Extend-Robotics/er_build_tools#37).
+#     - filename ends in .py or .pyi   (library modules, normal scripts)
+#     - first line of the file is a Python shebang (`^#!.*python`)
+#       — the only way the kernel recognises an extension-less file
+#       as Python (e.g. ROS nodes in scripts/ exec'd by name).
 #   Both rules are needed because they catch disjoint cases:
 #     - Library code under src/ has .py but no shebang (libraries are
-#       not meant to be directly executable), so mime-only would miss
-#       every src/ module — `file` reports them as text/plain since
-#       they have no shebang and Python has no magic number.
+#       not meant to be directly executable), so shebang-only would
+#       miss every src/ module.
 #     - ROS nodes named like `scripts/my_node` have a shebang but no
 #       .py extension, so extension-only would miss them.
-#   The earlier `find_python_files_here` shipped only the mime check
-#   and so silently skipped every .py library file under src/. The
-#   extension check fixes that; the mime check covers the no-extension
-#   case.
+#
+#   We do NOT use `file -bi` for the shebang case. libmagic produces
+#   false positives on Markdown READMEs whose first line is `# Title`
+#   (it sees `# something` as a Python comment and labels the whole
+#   file `text/x-python`). The kernel-level shebang rule is precise:
+#   `#!` must be the first two bytes for the file to be exec'd as
+#   Python, so we check that directly.
 #
 # SCOPE
 #   Two modes, picked automatically:
@@ -68,16 +66,15 @@ EXCLUDE_DIRS="${EXCLUDE_DIRS:-__pycache__}"
 
 # Print $1 to stdout iff it's a Python source file.
 #
-# `file` reports Python with either `text/x-python` or
-# `text/x-script.python` depending on libmagic version (see
-# Extend-Robotics/er_build_tools#37), so we grep for the substring
-# `python` in the mime line. `-b` strips the filename from the output
-# so a non-Python file whose name contains "python" doesn't slip in.
+# The shebang check reads the first 256 bytes of the file and inspects
+# only the first line. The byte cap stops us slurping a multi-MB binary
+# that happens to lack newlines; `head -n 1` then anchors the regex to
+# the first line as the kernel requires for a real shebang.
 emit_if_python() {
     case "$1" in
         *.py|*.pyi) printf '%s\n' "$1"; return 0 ;;
     esac
-    if [ -f "$1" ] && file -bi "$1" 2>/dev/null | grep -q python; then
+    if [ -f "$1" ] && head -c 256 "$1" 2>/dev/null | head -n 1 | grep -q '^#!.*python'; then
         printf '%s\n' "$1"
     fi
 }


### PR DESCRIPTION
## Summary

Ships `find_python_files.sh` as a shared discovery script that finds Python source files reliably, regardless of where it's run, and wires the local helper (`.helper_bash_functions`) to use it.

The old `find_python_files_here` used `find . -type f | file -i | grep x-python`, which silently skipped every Python file without a shebang — i.e. every library module under `src/`. The user-visible symptom: lint passed locally on `er_interface` while CI flagged 26-locals (and other) issues that real pylint runs would have caught (see [er_interface#133](https://github.com/Extend-Robotics/er_interface/pull/133) for the trail of debugging).

## What's in this PR

- **New `find_python_files.sh`**: detects Python by `.py`/`.pyi` extension OR Python shebang. Two modes — `git ls-files`+`git grep` when in a git work tree (free `.gitignore` respect), `find` with a minimal exclude list when not. Block comment captures rationale, scope, non-goals.
- **Updated `find_python_files_here`** in `.helper_bash_functions`: now just calls the script.
- **Persistent script cache** at `~/.find_python_files.sh` (not `/tmp/`) so it survives reboots without internet.
- **Auto-refresh on `update_helper_bash_functions`**: `rm`s the cache and re-fetches as part of the existing helper-update flow, so users don't drift onto stale versions.

## Detection rules — why both

| Style | Caught by | Otherwise missed because |
|---|---|---|
| `src/foo/bar.py` (library module, no shebang) | extension | `file -i` reports `text/plain` for shebang-less .py |
| `scripts/my_node` (executable, no extension) | shebang | extension-only globs miss them |

## Notable: shebang check, not mime

Earlier iterations used `file -bi`. Verified against `er_interface` and found it produces false positives on Markdown READMEs whose first line is `# Title` — libmagic interprets that as a Python comment and labels the whole file `text/x-python`. The kernel-level shebang rule (`#!` at byte 0) is precise and doesn't have that ambiguity, so the script checks it directly.

## Companion PR

- [Extend-Robotics/er_build_tools_internal#32](https://github.com/Extend-Robotics/er_build_tools_internal/pull/32) — wires the CI workflow to use this script for flake8 and pylint discovery. **Should merge after this one** so the `wget` from CI resolves.

## Test plan

- [x] Local helper finds files correctly in git mode (verified against `er_robot_launch` package)
- [x] Local helper finds files correctly in find mode (verified in non-git scratch dir)
- [x] Helper falls back to find mode when git is missing/broken
- [x] No false positives on Markdown READMEs (verified against `er_interface`)
- [x] Newly-discovered files have real Python shebangs (verified — 5 files in `er_interface`: 2 extension-less scripts + 3 `dynamic_reconfigure` cfg templates)
- [x] Blacklist semantics unchanged (`grep -v "^${pattern}"` still anchors correctly on repo-relative paths)