### PR TITLE
Fix er_python_linters_here hang on fresh Docker containers

### DIFF
--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -215,9 +215,31 @@ find_python_files_here() {
 }
 print_reinstall_warning() { echo -e "${Red}INFO: Just installed $1. Please re-run the last command to get the output and formatting that you're expecting.${Color_Off}"; }
 check_pylintrc() { if ! [ -f /tmp/pylintrc ]; then wget -O /tmp/pylintrc https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/pylintrc; fi; }
-check_apt_package() { if [[ $(dpkg -l | grep -w $1 | wc -l) -eq 0 ]]; then sudo apt update && sudo apt install -y $1; echo "installed"; fi; }
-er_flake8_here() { check_pylintrc; NEWLY_INSTALLED=$(check_apt_package "flake8"); flake8 --config /tmp/pylintrc --max-line-length ${LINTER_MAX_LINE_LENGTH}; local flake8_ret=$?; if [[ ${NEWLY_INSTALLED} == *"installed"* ]]; then print_reinstall_warning "flake8"; fi; return $flake8_ret; }
-er_pylint_here() { check_pylintrc; NEWLY_INSTALLED=$(check_apt_package "pylint");  pylint --rcfile /tmp/pylintrc --max-line-length ${LINTER_MAX_LINE_LENGTH} $(find_python_files_here); local pylint_ret=$?; if [[ ${NEWLY_INSTALLED} == *"installed"* ]]; then print_reinstall_warning "pylint"; fi; return $pylint_ret; }
+check_apt_package() {
+    if dpkg -l | grep -qw "$1"; then
+        return 0
+    fi
+    sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update && \
+    sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y \
+        -o Dpkg::Options::="--force-confnew" "$1"
+    return 1
+}
+er_flake8_here() {
+    check_pylintrc
+    check_apt_package "flake8"; local newly=$?
+    flake8 --config /tmp/pylintrc --max-line-length ${LINTER_MAX_LINE_LENGTH}
+    local flake8_ret=$?
+    [[ $newly -eq 1 ]] && print_reinstall_warning "flake8"
+    return $flake8_ret
+}
+er_pylint_here() {
+    check_pylintrc
+    check_apt_package "pylint"; local newly=$?
+    pylint --rcfile /tmp/pylintrc --max-line-length ${LINTER_MAX_LINE_LENGTH} $(find_python_files_here)
+    local pylint_ret=$?
+    [[ $newly -eq 1 ]] && print_reinstall_warning "pylint"
+    return $pylint_ret
+}
 er_pylint_sorted_here() { er_pylint_here | sort -V | grep -v "\*\*\*\*\*\*\*\*"; return ${PIPESTATUS[0]}; }
 er_pylint_single_file() { check_pylintrc; check_apt_package "pylint";  pylint --rcfile /tmp/pylintrc --max-line-length ${LINTER_MAX_LINE_LENGTH} $1; }
 er_pylint_single_file_sorted() { er_pylint_single_file $1 | sort -V | grep -v "\*\*\*\*\*\*\*\*"; return ${PIPESTATUS[0]}; }


### PR DESCRIPTION
## Summary

`er_pylint_here` and `er_flake8_here` wrapped `check_apt_package` in `$(...)` so they could grep its stdout for the literal `"installed"` and decide whether to print the reinstall warning. That command substitution captures stdout, hiding apt's progress output and -- the actual bug -- any interactive `debconf`/`needrestart` prompts that fire on a fresh Docker container. The install then silently blocks waiting for input the user cannot see, so `er_python_linters_here` looks like it just hangs; only the two `WARNING: apt does not have a stable CLI interface` lines (stderr) leak through.

The fix:
- Switch `check_apt_package` to `apt-get` with `DEBIAN_FRONTEND=noninteractive` and `NEEDRESTART_MODE=a` plus `-o Dpkg::Options::="--force-confnew"` so no interactive prompts are issued.
- Signal "newly installed" via return code (1) instead of stdout.
- Drop the `$(...)` wrapper in the callers, so apt's progress now reaches the terminal.

`er_pylint_single_file` already called `check_apt_package` without command substitution; it ignores the return value so it continues to work with the new exit-code semantics.

## Test plan

- [ ] On a fresh Docker container without `pylint`/`flake8` installed, run `er_python_linters_here`; apt's progress output should now be visible and the command should complete (or error) without hanging on an invisible prompt.
- [ ] On a host where `pylint` and `flake8` are already installed, run `er_python_linters_here`; should behave the same as before, with no spurious "Just installed" warning.
- [ ] On a fresh container with only one of `pylint`/`flake8` installed, run the corresponding `er_*_here`; should install the missing package, run the linter, and print the reinstall warning afterwards.
- [ ] `er_pylint_single_file <file.py>` still works on a fresh container.
- [ ] CI `check_bash` workflow passes (file still sources cleanly).