### PR TITLE
Strip PYTHONHOME/PYTHONPATH in linter helpers

### DIFF
--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -262,35 +262,42 @@ check_apt_package() {
         -o Dpkg::Options::="--force-confnew" "$1"
     return 1
 }
-er_flake8_here() {
+# Linter wrappers run as subshell functions with PYTHONHOME/PYTHONPATH unset, so uv's Python
+# isn't redirected to a foreign stdlib. (Isaac Sim images export PYTHONHOME pointing at a 3.11
+# tree; uv's 3.8 then fails with "No module named encodings" both at build and shim launch.)
+er_flake8_here() (
+    unset PYTHONHOME PYTHONPATH
     check_pylintrc
     check_linter_versions || return 1
     ensure_uv_tool_pinned "flake8" "$LINTER_FLAKE8_VERSION" "$LINTER_PYTHON_VERSION" || return 1
     echo -e "${Yellow}Running flake8...${Color_Off}" >&2
     flake8 --config /tmp/pylintrc --max-line-length ${LINTER_MAX_LINE_LENGTH}
-}
-er_pylint_here() {
+)
+er_pylint_here() (
+    unset PYTHONHOME PYTHONPATH
     check_pylintrc
     check_linter_versions || return 1
     ensure_uv_tool_pinned "pylint" "$LINTER_PYLINT_VERSION" "$LINTER_PYTHON_VERSION" || return 1
     echo -e "${Yellow}Running pylint...${Color_Off}" >&2
     pylint --rcfile /tmp/pylintrc --max-line-length ${LINTER_MAX_LINE_LENGTH} $(find_python_files_here)
-}
+)
 er_pylint_sorted_here() { er_pylint_here | sort -V | grep -v "\*\*\*\*\*\*\*\*"; return ${PIPESTATUS[0]}; }
-er_pylint_single_file() {
+er_pylint_single_file() (
+    unset PYTHONHOME PYTHONPATH
     check_pylintrc
     check_linter_versions || return 1
     ensure_uv_tool_pinned "pylint" "$LINTER_PYLINT_VERSION" "$LINTER_PYTHON_VERSION" || return 1
     echo -e "${Yellow}Running pylint on $1...${Color_Off}" >&2
     pylint --rcfile /tmp/pylintrc --max-line-length ${LINTER_MAX_LINE_LENGTH} "$1"
-}
+)
 er_pylint_single_file_sorted() { er_pylint_single_file "$1" | sort -V | grep -v "\*\*\*\*\*\*\*\*"; return ${PIPESTATUS[0]}; }
-er_ruff_here() {
+er_ruff_here() (
+    unset PYTHONHOME PYTHONPATH
     check_linter_versions || return 1
     ensure_uv_tool_pinned "ruff" "$LINTER_RUFF_VERSION" "$LINTER_PYTHON_VERSION" || return 1
     echo -e "${Yellow}Running ruff...${Color_Off}" >&2
     ruff check
-}
+)
 er_python_linters_here() { local ret=0
                            echo
                            er_pylint_sorted_here || ret=$?


### PR DESCRIPTION
## Summary

On dev images that export `PYTHONHOME` (e.g. Isaac Sim points it at `/workspace/isaaclab/_isaac_sim/kit/python`, a Python 3.11 tree), uv's downloaded 3.8 interpreter inherits those vars and can't find its own stdlib:

```
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
ModuleNotFoundError: No module named 'encodings'
```

This breaks two things during `er_python_linters_here`:

1. **Build-time:** `uv tool install pylint==2.10.2` pulls `wrapt==1.12.1`, which has no wheel for cpython-3.8 on modern manylinux and falls through to a source build. The build subprocess inherits `PYTHONHOME`/`PYTHONPATH` and aborts before it can run `setup.py`.
2. **Run-time:** the `flake8` / `pylint` shim binaries are Python entrypoints; each shim's interpreter hits the same poisoned env and dies on launch.

ruff is unaffected — Rust binary.

## Fix

Each `er_*_here` is now a **subshell function** (`() ( … )` instead of `() { … }`) with `unset PYTHONHOME PYTHONPATH` at the top. Subshell semantics keep the unset scoped to the call — your shell's vars are untouched on return. The unset propagates down into `ensure_uv_tool_pinned` (and through to `uv tool install`'s build subprocesses) and into the linter binaries themselves.

## Test plan

- [x] On Isaac Sim container (PYTHONHOME=`…/_isaac_sim/kit/python`, PYTHONPATH= long Isaac/ROS list), `er_python_linters_here` installs pylint/flake8/ruff cleanly and runs all three without `ModuleNotFoundError: No module named 'encodings'`.
- [ ] Verify `echo "$PYTHONHOME"` and `echo "$PYTHONPATH"` are unchanged in the calling shell after the linter run.
- [ ] On a clean container with no PYTHONHOME/PYTHONPATH set, behaviour is unchanged.
- [ ] Already-installed pinned versions remain a no-op (idempotent path).