### PR TITLE
Add urdf2usd: bwrap-based urdf-usd-converter wrapper for glibc-2.31 hosts (ERD-1633)

### DIFF
--- a/bin/build-and-release-urdf2usd.sh
+++ b/bin/build-and-release-urdf2usd.sh
@@ -113,8 +113,17 @@ fi
 build_dir="$(mktemp -d)"
 builder_image="urdf-usd-converter-rootfs-builder:${converter_version}"
 builder_container="urdf-usd-converter-rootfs-builder-${converter_version//./-}-$$"
+publish_phase=pre_draft
 
-trap 'docker rm -f "${builder_container}" >/dev/null 2>&1 || true; rm -rf "${build_dir}"' EXIT
+cleanup_release() {
+    docker rm -f "${builder_container}" >/dev/null 2>&1 || true
+    rm -rf "${build_dir}"
+    if [ "${publish_phase}" = draft_created ] || [ "${publish_phase}" = upload_verified ]; then
+        echo "==> Cleaning up unpublished draft release ${release_tag}" >&2
+        gh release delete "${release_tag}" --repo "${repo}" --yes --cleanup-tag >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup_release EXIT
 
 echo "==> Building ${builder_image} from ${dockerfile_path}"
 docker build \
@@ -130,17 +139,38 @@ docker export "${builder_container}" | gzip -9 > "${build_dir}/${asset_name}"
 asset_size_mb=$(du -m "${build_dir}/${asset_name}" | cut -f1)
 echo "==> Tarball: ${asset_name} (${asset_size_mb} MB)"
 
-echo "==> Computing sha256"
-( cd "${build_dir}" && sha256sum "${asset_name}" > "${sha256_name}" )
+# Stage the wrapper into build_dir so the sha256 manifest covers both
+# the tarball and the wrapper with bare basenames the installer can
+# verify with a single `sha256sum -c` in the download dir.
+cp "${wrapper_path}" "${build_dir}/urdf2usd"
 
-echo "==> Creating release ${release_tag} in ${repo}"
+echo "==> Computing sha256 manifest (rootfs + wrapper)"
+( cd "${build_dir}" && sha256sum "${asset_name}" urdf2usd > "${sha256_name}" )
+
+echo "==> Creating draft release ${release_tag} in ${repo}"
 gh release create "${release_tag}" \
     "${build_dir}/${asset_name}" \
     "${build_dir}/${sha256_name}" \
-    "${wrapper_path}" \
+    "${build_dir}/urdf2usd" \
     --repo "${repo}" \
+    --draft \
     --title "urdf2usd rootfs ${converter_version}" \
     --notes "Rootfs containing urdf-usd-converter==${converter_version} built on python:3.12-slim (Debian bookworm, glibc 2.36) for use with the bwrap-based urdf2usd wrapper."
+publish_phase=draft_created
+
+echo "==> Verifying all three assets uploaded to draft"
+uploaded_assets="$(gh release view "${release_tag}" --repo "${repo}" --json assets --jq '.assets[].name')"
+for expected in "${asset_name}" "${sha256_name}" urdf2usd; do
+    grep -qxF "${expected}" <<<"${uploaded_assets}" || {
+        echo "ERROR: expected asset ${expected} missing from draft release; aborting before publish." >&2
+        exit 1
+    }
+done
+publish_phase=upload_verified
+
+echo "==> Publishing release"
+gh release edit "${release_tag}" --repo "${repo}" --draft=false >/dev/null
+publish_phase=published
 
 echo
 echo "Done. Asset URLs:"

--- a/bin/build-and-release-urdf2usd.sh
+++ b/bin/build-and-release-urdf2usd.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Build the urdf2usd rootfs from a pinned urdf-usd-converter version and
+# publish it as a GitHub Release asset. The asset is consumed at install
+# time by the (consumer-side) installer, which downloads the tarball,
+# extracts it to /opt/urdf-usd-converter-rootfs/, and runs the converter
+# under bwrap so no docker is needed on the consumer machine.
+#
+# Run with:
+#   bin/build-and-release-urdf2usd.sh <converter-version> [--repo OWNER/REPO] [--force]
+# Example:
+#   bin/build-and-release-urdf2usd.sh 0.1.3
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: build-and-release-urdf2usd.sh <converter-version> [--repo OWNER/REPO] [--force]
+
+Builds a docker image with urdf-usd-converter==<converter-version> on a
+python:3.12-slim base, exports its filesystem as a gzip tarball, and uploads
+it as a GitHub Release asset.
+
+Requires docker, gh (authenticated), tar, and gzip on the local machine.
+
+Options:
+  --repo OWNER/REPO  Target GitHub repository
+                     (default: Extend-Robotics/er_build_tools)
+  --force            Delete an existing release with the same tag and re-create it
+EOF
+    exit 1
+}
+
+converter_version=""
+repo="Extend-Robotics/er_build_tools"
+force=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo) repo="$2"; shift 2;;
+        --force) force=1; shift;;
+        -h|--help) usage;;
+        -*) echo "Unknown option: $1" >&2; usage;;
+        *)
+            if [ -z "${converter_version}" ]; then
+                converter_version="$1"
+                shift
+            else
+                echo "Unexpected positional argument: $1" >&2
+                usage
+            fi
+            ;;
+    esac
+done
+
+[ -z "${converter_version}" ] && usage
+
+for required_command in docker gh tar gzip; do
+    command -v "${required_command}" >/dev/null || {
+        echo "ERROR: required command not found in PATH: ${required_command}" >&2
+        exit 1
+    }
+done
+
+gh auth status >/dev/null 2>&1 || {
+    echo "ERROR: gh is not authenticated. Run 'gh auth login' first." >&2
+    exit 1
+}
+
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+dockerfile_path="${script_dir}/../dockerfiles/urdf_usd_converter.Dockerfile"
+dockerfile_context="${script_dir}/../dockerfiles"
+
+[ -f "${dockerfile_path}" ] || {
+    echo "ERROR: dockerfile not found: ${dockerfile_path}" >&2
+    exit 1
+}
+
+release_tag="urdf2usd-v${converter_version}"
+asset_name="urdf-usd-converter-rootfs-${converter_version}.tar.gz"
+
+if gh release view "${release_tag}" --repo "${repo}" >/dev/null 2>&1; then
+    if [ "${force}" -eq 1 ]; then
+        echo "==> Deleting existing release ${release_tag}"
+        gh release delete "${release_tag}" --repo "${repo}" --yes
+    else
+        echo "ERROR: release ${release_tag} already exists in ${repo}." >&2
+        echo "       Bump the version, or pass --force to overwrite." >&2
+        exit 1
+    fi
+fi
+
+build_dir="$(mktemp -d)"
+builder_image="urdf-usd-converter-rootfs-builder:${converter_version}"
+builder_container="urdf-usd-converter-rootfs-builder-${converter_version//./-}-$$"
+
+trap 'docker rm -f "${builder_container}" >/dev/null 2>&1 || true; rm -rf "${build_dir}"' EXIT
+
+echo "==> Building ${builder_image} from ${dockerfile_path}"
+docker build \
+    --build-arg "CONVERTER_VERSION=${converter_version}" \
+    -t "${builder_image}" \
+    -f "${dockerfile_path}" \
+    "${dockerfile_context}"
+
+echo "==> Exporting and compressing rootfs"
+docker create --name "${builder_container}" "${builder_image}" >/dev/null
+docker export "${builder_container}" | gzip -9 > "${build_dir}/${asset_name}"
+
+asset_size_mb=$(du -m "${build_dir}/${asset_name}" | cut -f1)
+echo "==> Tarball: ${asset_name} (${asset_size_mb} MB)"
+
+echo "==> Creating release ${release_tag} in ${repo}"
+gh release create "${release_tag}" "${build_dir}/${asset_name}" \
+    --repo "${repo}" \
+    --title "urdf2usd rootfs ${converter_version}" \
+    --notes "Rootfs containing urdf-usd-converter==${converter_version} built on python:3.12-slim (Debian bookworm, glibc 2.36) for use with the bwrap-based urdf2usd wrapper."
+
+echo
+echo "Done. Asset URL:"
+echo "  https://github.com/${repo}/releases/download/${release_tag}/${asset_name}"

--- a/bin/build-and-release-urdf2usd.sh
+++ b/bin/build-and-release-urdf2usd.sh
@@ -85,11 +85,14 @@ gh auth status >/dev/null 2>&1 || {
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 dockerfile_path="${script_dir}/../dockerfiles/urdf_usd_converter.Dockerfile"
 dockerfile_context="${script_dir}/../dockerfiles"
+wrapper_path="${script_dir}/urdf2usd"
 
-[ -f "${dockerfile_path}" ] || {
-    echo "ERROR: dockerfile not found: ${dockerfile_path}" >&2
-    exit 1
-}
+for required_file in "${dockerfile_path}" "${wrapper_path}"; do
+    [ -f "${required_file}" ] || {
+        echo "ERROR: required file not found: ${required_file}" >&2
+        exit 1
+    }
+done
 
 release_tag="urdf2usd-v${converter_version}"
 asset_name="urdf-usd-converter-rootfs-${converter_version}.tar.gz"
@@ -126,11 +129,14 @@ asset_size_mb=$(du -m "${build_dir}/${asset_name}" | cut -f1)
 echo "==> Tarball: ${asset_name} (${asset_size_mb} MB)"
 
 echo "==> Creating release ${release_tag} in ${repo}"
-gh release create "${release_tag}" "${build_dir}/${asset_name}" \
+gh release create "${release_tag}" \
+    "${build_dir}/${asset_name}" \
+    "${wrapper_path}" \
     --repo "${repo}" \
     --title "urdf2usd rootfs ${converter_version}" \
     --notes "Rootfs containing urdf-usd-converter==${converter_version} built on python:3.12-slim (Debian bookworm, glibc 2.36) for use with the bwrap-based urdf2usd wrapper."
 
 echo
-echo "Done. Asset URL:"
+echo "Done. Asset URLs:"
 echo "  https://github.com/${repo}/releases/download/${release_tag}/${asset_name}"
+echo "  https://github.com/${repo}/releases/download/${release_tag}/urdf2usd"

--- a/bin/build-and-release-urdf2usd.sh
+++ b/bin/build-and-release-urdf2usd.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SKIP_CHECK
 # Build the urdf2usd rootfs from a pinned urdf-usd-converter version and
 # publish it as a GitHub Release asset. The asset is consumed at install
 # time by the (consumer-side) installer, which downloads the tarball,
@@ -60,7 +61,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-for required_command in docker gh tar gzip curl python3; do
+for required_command in docker gh tar gzip curl python3 sha256sum; do
     command -v "${required_command}" >/dev/null || {
         echo "ERROR: required command not found in PATH: ${required_command}" >&2
         exit 1
@@ -96,6 +97,7 @@ done
 
 release_tag="urdf2usd-v${converter_version}"
 asset_name="urdf-usd-converter-rootfs-${converter_version}.tar.gz"
+sha256_name="${asset_name}.sha256"
 
 if gh release view "${release_tag}" --repo "${repo}" >/dev/null 2>&1; then
     if [ "${force}" -eq 1 ]; then
@@ -128,9 +130,13 @@ docker export "${builder_container}" | gzip -9 > "${build_dir}/${asset_name}"
 asset_size_mb=$(du -m "${build_dir}/${asset_name}" | cut -f1)
 echo "==> Tarball: ${asset_name} (${asset_size_mb} MB)"
 
+echo "==> Computing sha256"
+( cd "${build_dir}" && sha256sum "${asset_name}" > "${sha256_name}" )
+
 echo "==> Creating release ${release_tag} in ${repo}"
 gh release create "${release_tag}" \
     "${build_dir}/${asset_name}" \
+    "${build_dir}/${sha256_name}" \
     "${wrapper_path}" \
     --repo "${repo}" \
     --title "urdf2usd rootfs ${converter_version}" \
@@ -138,5 +144,7 @@ gh release create "${release_tag}" \
 
 echo
 echo "Done. Asset URLs:"
-echo "  https://github.com/${repo}/releases/download/${release_tag}/${asset_name}"
-echo "  https://github.com/${repo}/releases/download/${release_tag}/urdf2usd"
+release_base="https://github.com/${repo}/releases/download/${release_tag}"
+echo "  ${release_base}/${asset_name}"
+echo "  ${release_base}/${sha256_name}"
+echo "  ${release_base}/urdf2usd"

--- a/bin/build-and-release-urdf2usd.sh
+++ b/bin/build-and-release-urdf2usd.sh
@@ -6,21 +6,24 @@
 # under bwrap so no docker is needed on the consumer machine.
 #
 # Run with:
-#   bin/build-and-release-urdf2usd.sh <converter-version> [--repo OWNER/REPO] [--force]
-# Example:
-#   bin/build-and-release-urdf2usd.sh 0.1.3
+#   bin/build-and-release-urdf2usd.sh [<converter-version>] [--repo OWNER/REPO] [--force]
+# If converter-version is omitted, the latest release on PyPI is used.
 
 set -euo pipefail
 
 usage() {
     cat >&2 <<'EOF'
-Usage: build-and-release-urdf2usd.sh <converter-version> [--repo OWNER/REPO] [--force]
+Usage: build-and-release-urdf2usd.sh [<converter-version>] [--repo OWNER/REPO] [--force]
 
 Builds a docker image with urdf-usd-converter==<converter-version> on a
 python:3.12-slim base, exports its filesystem as a gzip tarball, and uploads
 it as a GitHub Release asset.
 
-Requires docker, gh (authenticated), tar, and gzip on the local machine.
+If <converter-version> is omitted, the latest release of urdf-usd-converter
+on PyPI is used.
+
+Requires docker, gh (authenticated), tar, gzip, curl, and python3 on the
+local machine.
 
 Options:
   --repo OWNER/REPO  Target GitHub repository
@@ -28,6 +31,11 @@ Options:
   --force            Delete an existing release with the same tag and re-create it
 EOF
     exit 1
+}
+
+fetch_latest_pypi_version() {
+    curl -fsSL https://pypi.org/pypi/urdf-usd-converter/json \
+        | python3 -c 'import json,sys;print(json.load(sys.stdin)["info"]["version"])'
 }
 
 converter_version=""
@@ -52,14 +60,22 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-[ -z "${converter_version}" ] && usage
-
-for required_command in docker gh tar gzip; do
+for required_command in docker gh tar gzip curl python3; do
     command -v "${required_command}" >/dev/null || {
         echo "ERROR: required command not found in PATH: ${required_command}" >&2
         exit 1
     }
 done
+
+if [ -z "${converter_version}" ]; then
+    echo "==> No converter version specified; fetching latest from PyPI"
+    converter_version="$(fetch_latest_pypi_version)"
+    [ -n "${converter_version}" ] || {
+        echo "ERROR: failed to fetch latest urdf-usd-converter version from PyPI" >&2
+        exit 1
+    }
+    echo "==> Latest urdf-usd-converter on PyPI: ${converter_version}"
+fi
 
 gh auth status >/dev/null 2>&1 || {
     echo "ERROR: gh is not authenticated. Run 'gh auth login' first." >&2

--- a/bin/install-urdf2usd.sh
+++ b/bin/install-urdf2usd.sh
@@ -5,6 +5,8 @@
 # GitHub Release, extracts it to /opt/urdf-usd-converter-rootfs/, installs
 # bubblewrap, and drops the urdf2usd wrapper into /usr/local/bin/.
 #
+# If --version is not given, the latest urdf2usd-v* GitHub Release is used.
+#
 # Needs root (writes to /opt and /usr/local/bin). Run with:
 #   curl -fsSL https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/main/bin/install-urdf2usd.sh | sudo bash
 # Or with a specific version:
@@ -12,11 +14,20 @@
 
 set -euo pipefail
 
-DEFAULT_VERSION="0.1.3"
-
-version="${DEFAULT_VERSION}"
+version=""
 repo="Extend-Robotics/er_build_tools"
 branch="main"
+
+fetch_latest_release_version() {
+    curl -fsSL "https://api.github.com/repos/${repo}/releases" \
+        | python3 -c '
+import json, sys
+releases = json.load(sys.stdin)
+tags = [r["tag_name"] for r in releases
+        if r["tag_name"].startswith("urdf2usd-v") and not r.get("prerelease")]
+print(tags[0][len("urdf2usd-v"):] if tags else "")
+'
+}
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -41,12 +52,22 @@ done
     exit 1
 }
 
-for required_command in curl tar gzip apt-get; do
+for required_command in curl tar gzip apt-get python3; do
     command -v "${required_command}" >/dev/null || {
         echo "ERROR: required command not found: ${required_command}" >&2
         exit 1
     }
 done
+
+if [ -z "${version}" ]; then
+    echo "==> No version specified; fetching latest urdf2usd release from ${repo}"
+    version="$(fetch_latest_release_version)"
+    [ -n "${version}" ] || {
+        echo "ERROR: no urdf2usd-v* release found in ${repo}" >&2
+        exit 1
+    }
+    echo "==> Latest urdf2usd release: ${version}"
+fi
 
 release_tag="urdf2usd-v${version}"
 asset_name="urdf-usd-converter-rootfs-${version}.tar.gz"

--- a/bin/install-urdf2usd.sh
+++ b/bin/install-urdf2usd.sh
@@ -16,7 +16,6 @@ set -euo pipefail
 
 version=""
 repo="Extend-Robotics/er_build_tools"
-branch="main"
 
 fetch_latest_release_version() {
     curl -fsSL "https://api.github.com/repos/${repo}/releases" \
@@ -33,9 +32,8 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --version) version="$2"; shift 2;;
         --repo)    repo="$2"; shift 2;;
-        --branch)  branch="$2"; shift 2;;
         -h|--help)
-            echo "Usage: install-urdf2usd.sh [--version X.Y.Z] [--repo OWNER/REPO] [--branch BRANCH]"
+            echo "Usage: install-urdf2usd.sh [--version X.Y.Z] [--repo OWNER/REPO]"
             exit 0
             ;;
         *)
@@ -71,8 +69,9 @@ fi
 
 release_tag="urdf2usd-v${version}"
 asset_name="urdf-usd-converter-rootfs-${version}.tar.gz"
-asset_url="https://github.com/${repo}/releases/download/${release_tag}/${asset_name}"
-wrapper_url="https://raw.githubusercontent.com/${repo}/${branch}/bin/urdf2usd"
+release_base="https://github.com/${repo}/releases/download/${release_tag}"
+asset_url="${release_base}/${asset_name}"
+wrapper_url="${release_base}/urdf2usd"
 
 rootfs_dir=/opt/urdf-usd-converter-rootfs
 wrapper_path=/usr/local/bin/urdf2usd

--- a/bin/install-urdf2usd.sh
+++ b/bin/install-urdf2usd.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SKIP_CHECK
 # Installer for urdf2usd on glibc-2.31 hosts (Ubuntu 20.04 / ROS Noetic).
 #
 # Downloads a pre-built rootfs containing urdf-usd-converter from a public
@@ -50,7 +51,7 @@ done
     exit 1
 }
 
-for required_command in curl tar gzip apt-get python3; do
+for required_command in curl tar gzip apt-get python3 sha256sum; do
     command -v "${required_command}" >/dev/null || {
         echo "ERROR: required command not found: ${required_command}" >&2
         exit 1
@@ -69,11 +70,15 @@ fi
 
 release_tag="urdf2usd-v${version}"
 asset_name="urdf-usd-converter-rootfs-${version}.tar.gz"
+sha256_name="${asset_name}.sha256"
 release_base="https://github.com/${repo}/releases/download/${release_tag}"
 asset_url="${release_base}/${asset_name}"
+sha256_url="${release_base}/${sha256_name}"
 wrapper_url="${release_base}/urdf2usd"
 
 rootfs_dir=/opt/urdf-usd-converter-rootfs
+new_rootfs_dir="${rootfs_dir}.new.$$"
+old_rootfs_dir="${rootfs_dir}.old.$$"
 wrapper_path=/usr/local/bin/urdf2usd
 
 if ! command -v bwrap >/dev/null; then
@@ -83,15 +88,33 @@ if ! command -v bwrap >/dev/null; then
 fi
 
 tmp_dir="$(mktemp -d)"
-trap 'rm -rf "${tmp_dir}"' EXIT
+trap 'rm -rf "${tmp_dir}" "${new_rootfs_dir}"' EXIT
 
 echo "==> Downloading rootfs ${version} from ${asset_url}"
 curl -fsSL -o "${tmp_dir}/${asset_name}" "${asset_url}"
 
-echo "==> Replacing rootfs at ${rootfs_dir}"
-rm -rf "${rootfs_dir}"
-mkdir -p "${rootfs_dir}"
-tar -xzf "${tmp_dir}/${asset_name}" -C "${rootfs_dir}"
+echo "==> Downloading checksum from ${sha256_url}"
+curl -fsSL -o "${tmp_dir}/${sha256_name}" "${sha256_url}"
+
+echo "==> Verifying tarball checksum"
+( cd "${tmp_dir}" && sha256sum -c "${sha256_name}" )
+
+echo "==> Extracting rootfs to staging dir ${new_rootfs_dir}"
+rm -rf "${new_rootfs_dir}"
+mkdir -p "${new_rootfs_dir}"
+tar -xzf "${tmp_dir}/${asset_name}" -C "${new_rootfs_dir}"
+
+[ -x "${new_rootfs_dir}/usr/local/bin/urdf_usd_converter" ] || {
+    echo "ERROR: extracted rootfs is missing /usr/local/bin/urdf_usd_converter; tarball is corrupt or wrong shape." >&2
+    exit 1
+}
+
+echo "==> Swapping rootfs into place at ${rootfs_dir}"
+if [ -d "${rootfs_dir}" ]; then
+    mv "${rootfs_dir}" "${old_rootfs_dir}"
+fi
+mv "${new_rootfs_dir}" "${rootfs_dir}"
+rm -rf "${old_rootfs_dir}"
 
 echo "==> Installing wrapper at ${wrapper_path}"
 curl -fsSL -o "${wrapper_path}" "${wrapper_url}"

--- a/bin/install-urdf2usd.sh
+++ b/bin/install-urdf2usd.sh
@@ -80,6 +80,7 @@ rootfs_dir=/opt/urdf-usd-converter-rootfs
 new_rootfs_dir="${rootfs_dir}.new.$$"
 old_rootfs_dir="${rootfs_dir}.old.$$"
 wrapper_path=/usr/local/bin/urdf2usd
+wrapper_staging_path="${wrapper_path}.new.$$"
 
 if ! command -v bwrap >/dev/null; then
     echo "==> Installing bubblewrap"
@@ -88,19 +89,59 @@ if ! command -v bwrap >/dev/null; then
 fi
 
 tmp_dir="$(mktemp -d)"
-trap 'rm -rf "${tmp_dir}" "${new_rootfs_dir}"' EXIT
+swap_phase=pre_swap
 
+# Phase-aware cleanup so an interrupted install never leaves /opt without
+# a rootfs:
+#   pre_swap    — nothing in /opt has moved yet; just drop staging.
+#   mid_swap    — old rootfs was renamed to .old.$$ but new rename hasn't
+#                 happened or hasn't succeeded; restore the old one.
+#   swapped     — new rootfs is in place; drop the leftover .old.$$.
+install_cleanup() {
+    rm -rf "${tmp_dir}" "${wrapper_staging_path}"
+    case "${swap_phase}" in
+        pre_swap)
+            rm -rf "${new_rootfs_dir}"
+            ;;
+        mid_swap)
+            if [ ! -d "${rootfs_dir}" ] && [ -d "${old_rootfs_dir}" ]; then
+                echo "==> Install interrupted mid-swap; restoring previous rootfs at ${rootfs_dir}" >&2
+                mv "${old_rootfs_dir}" "${rootfs_dir}"
+            fi
+            rm -rf "${new_rootfs_dir}"
+            ;;
+        swapped)
+            rm -rf "${old_rootfs_dir}"
+            ;;
+    esac
+}
+trap install_cleanup EXIT
+
+# Download every release artefact into tmp_dir BEFORE touching /opt or
+# /usr/local/bin, so a partial download can never leave a half-installed
+# host. The sha256 manifest published by build-and-release-urdf2usd.sh
+# covers the rootfs tarball AND the urdf2usd wrapper; both must verify.
 echo "==> Downloading rootfs ${version} from ${asset_url}"
 curl -fsSL -o "${tmp_dir}/${asset_name}" "${asset_url}"
+
+echo "==> Downloading wrapper from ${wrapper_url}"
+curl -fsSL -o "${tmp_dir}/urdf2usd" "${wrapper_url}"
 
 echo "==> Downloading checksum from ${sha256_url}"
 curl -fsSL -o "${tmp_dir}/${sha256_name}" "${sha256_url}"
 
-echo "==> Verifying tarball checksum"
+echo "==> Verifying sha256 manifest covers both rootfs tarball and wrapper"
+for expected in "${asset_name}" urdf2usd; do
+    grep -qE "  ${expected}\$" "${tmp_dir}/${sha256_name}" || {
+        echo "ERROR: sha256 manifest does not cover ${expected}; release is malformed." >&2
+        exit 1
+    }
+done
+
+echo "==> Verifying checksums"
 ( cd "${tmp_dir}" && sha256sum -c "${sha256_name}" )
 
 echo "==> Extracting rootfs to staging dir ${new_rootfs_dir}"
-rm -rf "${new_rootfs_dir}"
 mkdir -p "${new_rootfs_dir}"
 tar -xzf "${tmp_dir}/${asset_name}" -C "${new_rootfs_dir}"
 
@@ -109,16 +150,22 @@ tar -xzf "${tmp_dir}/${asset_name}" -C "${new_rootfs_dir}"
     exit 1
 }
 
+# Prepare the wrapper on the same filesystem as ${wrapper_path} so the
+# final mv is a single rename(2) and other processes never see a
+# half-written or non-executable wrapper file.
+cp "${tmp_dir}/urdf2usd" "${wrapper_staging_path}"
+chmod +x "${wrapper_staging_path}"
+
 echo "==> Swapping rootfs into place at ${rootfs_dir}"
+swap_phase=mid_swap
 if [ -d "${rootfs_dir}" ]; then
     mv "${rootfs_dir}" "${old_rootfs_dir}"
 fi
 mv "${new_rootfs_dir}" "${rootfs_dir}"
-rm -rf "${old_rootfs_dir}"
+swap_phase=swapped
 
 echo "==> Installing wrapper at ${wrapper_path}"
-curl -fsSL -o "${wrapper_path}" "${wrapper_url}"
-chmod +x "${wrapper_path}"
+mv "${wrapper_staging_path}" "${wrapper_path}"
 
 echo
 echo "Done. Test with:"

--- a/bin/install-urdf2usd.sh
+++ b/bin/install-urdf2usd.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Installer for urdf2usd on glibc-2.31 hosts (Ubuntu 20.04 / ROS Noetic).
+#
+# Downloads a pre-built rootfs containing urdf-usd-converter from a public
+# GitHub Release, extracts it to /opt/urdf-usd-converter-rootfs/, installs
+# bubblewrap, and drops the urdf2usd wrapper into /usr/local/bin/.
+#
+# Needs root (writes to /opt and /usr/local/bin). Run with:
+#   curl -fsSL https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/main/bin/install-urdf2usd.sh | sudo bash
+# Or with a specific version:
+#   curl -fsSL .../install-urdf2usd.sh | sudo bash -s -- --version 0.1.3
+
+set -euo pipefail
+
+DEFAULT_VERSION="0.1.3"
+
+version="${DEFAULT_VERSION}"
+repo="Extend-Robotics/er_build_tools"
+branch="main"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) version="$2"; shift 2;;
+        --repo)    repo="$2"; shift 2;;
+        --branch)  branch="$2"; shift 2;;
+        -h|--help)
+            echo "Usage: install-urdf2usd.sh [--version X.Y.Z] [--repo OWNER/REPO] [--branch BRANCH]"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+[ "$(id -u)" -eq 0 ] || {
+    echo "ERROR: this installer needs root (writes to /opt and /usr/local/bin)." >&2
+    echo "Pipe to sudo bash, e.g.:" >&2
+    echo "  curl -fsSL .../install-urdf2usd.sh | sudo bash" >&2
+    exit 1
+}
+
+for required_command in curl tar gzip apt-get; do
+    command -v "${required_command}" >/dev/null || {
+        echo "ERROR: required command not found: ${required_command}" >&2
+        exit 1
+    }
+done
+
+release_tag="urdf2usd-v${version}"
+asset_name="urdf-usd-converter-rootfs-${version}.tar.gz"
+asset_url="https://github.com/${repo}/releases/download/${release_tag}/${asset_name}"
+wrapper_url="https://raw.githubusercontent.com/${repo}/${branch}/bin/urdf2usd"
+
+rootfs_dir=/opt/urdf-usd-converter-rootfs
+wrapper_path=/usr/local/bin/urdf2usd
+
+if ! command -v bwrap >/dev/null; then
+    echo "==> Installing bubblewrap"
+    apt-get update
+    apt-get install -y bubblewrap
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+echo "==> Downloading rootfs ${version} from ${asset_url}"
+curl -fsSL -o "${tmp_dir}/${asset_name}" "${asset_url}"
+
+echo "==> Replacing rootfs at ${rootfs_dir}"
+rm -rf "${rootfs_dir}"
+mkdir -p "${rootfs_dir}"
+tar -xzf "${tmp_dir}/${asset_name}" -C "${rootfs_dir}"
+
+echo "==> Installing wrapper at ${wrapper_path}"
+curl -fsSL -o "${wrapper_path}" "${wrapper_url}"
+chmod +x "${wrapper_path}"
+
+echo
+echo "Done. Test with:"
+echo "  urdf2usd --help"

--- a/bin/urdf2usd
+++ b/bin/urdf2usd
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SKIP_CHECK
 # Wrapper for urdf-usd-converter. Runs the pinned converter under bwrap
 # inside a pre-installed rootfs at /opt/urdf-usd-converter-rootfs/, so a
 # glibc-2.31 host (e.g. Ubuntu 20.04 / ROS Noetic) can run a wheel that

--- a/bin/urdf2usd
+++ b/bin/urdf2usd
@@ -29,15 +29,41 @@ command -v bwrap >/dev/null || {
     exit 1
 }
 
-# Bind common data roots into the sandbox so absolute paths to URDFs,
-# meshes, and output directories resolve. Add more entries here if your
-# inputs live elsewhere (or symlink them into one of these roots).
+# Bind data roots into the sandbox so absolute paths to URDFs, meshes,
+# and output directories resolve. /cortex is the project data root and
+# is required; the rest are conventional Linux roots that the converter
+# may need for inputs or temp files.
+required_host_dirs=(/cortex)
+optional_host_dirs=(/home /tmp /var/tmp /mnt /media)
+
 host_bind_args=()
-for host_dir in /cortex /home /tmp /var/tmp /mnt /media; do
-    if [ -d "${host_dir}" ]; then
-        host_bind_args+=(--bind "${host_dir}" "${host_dir}")
-    fi
+for required_dir in "${required_host_dirs[@]}"; do
+    [ -d "${required_dir}" ] || {
+        echo "ERROR: required bind dir ${required_dir} not found on host." >&2
+        echo "  The sandboxed converter needs read/write access to ${required_dir} for inputs and outputs." >&2
+        echo "  Edit required_host_dirs at the top of $0 if the data root has moved." >&2
+        exit 1
+    }
+    host_bind_args+=(--bind "${required_dir}" "${required_dir}")
 done
+for optional_dir in "${optional_host_dirs[@]}"; do
+    [ -d "${optional_dir}" ] && host_bind_args+=(--bind "${optional_dir}" "${optional_dir}")
+done
+
+# Ensure the user's cwd is reachable inside the sandbox; bwrap --chdir
+# fails if the target path doesn't exist there. Bind it explicitly if
+# it isn't already covered by the lists above (e.g. user is running
+# from /opt/foo or /srv/data).
+cwd="$(pwd)"
+cwd_already_bound=0
+for bound_dir in "${required_host_dirs[@]}" "${optional_host_dirs[@]}"; do
+    case "${cwd}/" in
+        "${bound_dir}"/*) cwd_already_bound=1; break;;
+    esac
+done
+if [ "${cwd_already_bound}" -eq 0 ]; then
+    host_bind_args+=(--bind "${cwd}" "${cwd}")
+fi
 
 exec bwrap \
     --ro-bind "${rootfs}" / \
@@ -45,5 +71,5 @@ exec bwrap \
     --dev /dev \
     "${host_bind_args[@]}" \
     --setenv PATH /usr/local/bin:/usr/bin:/bin \
-    --chdir "$(pwd)" \
+    --chdir "${cwd}" \
     /usr/local/bin/urdf_usd_converter "$@"

--- a/bin/urdf2usd
+++ b/bin/urdf2usd
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Wrapper for urdf-usd-converter. Runs the pinned converter under bwrap
+# inside a pre-installed rootfs at /opt/urdf-usd-converter-rootfs/, so a
+# glibc-2.31 host (e.g. Ubuntu 20.04 / ROS Noetic) can run a wheel that
+# requires glibc 2.35.
+#
+# Install with bin/install-urdf2usd.sh, or bake the rootfs into your image
+# at build time per docs/urdf2usd.md.
+#
+# Once the host migrates to a glibc-2.35+ base (Ubuntu 22.04+), this
+# wrapper can be removed and urdf-usd-converter installed natively (the
+# converter's CLI is `urdf_usd_converter`).
+
+set -euo pipefail
+
+rootfs=/opt/urdf-usd-converter-rootfs
+
+[ -d "${rootfs}" ] || {
+    echo "ERROR: rootfs not found at ${rootfs}." >&2
+    echo "Install with:" >&2
+    echo "  curl -fsSL https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/main/bin/install-urdf2usd.sh | sudo bash" >&2
+    exit 1
+}
+
+command -v bwrap >/dev/null || {
+    echo "ERROR: bwrap (bubblewrap) not installed. Install with:" >&2
+    echo "  sudo apt-get install -y bubblewrap" >&2
+    exit 1
+}
+
+# Bind common data roots into the sandbox so absolute paths to URDFs,
+# meshes, and output directories resolve. Add more entries here if your
+# inputs live elsewhere (or symlink them into one of these roots).
+host_bind_args=()
+for host_dir in /cortex /home /tmp /var/tmp /mnt /media; do
+    if [ -d "${host_dir}" ]; then
+        host_bind_args+=(--bind "${host_dir}" "${host_dir}")
+    fi
+done
+
+exec bwrap \
+    --ro-bind "${rootfs}" / \
+    --proc /proc \
+    --dev /dev \
+    "${host_bind_args[@]}" \
+    --setenv PATH /usr/local/bin:/usr/bin:/bin \
+    --chdir "$(pwd)" \
+    /usr/local/bin/urdf_usd_converter "$@"

--- a/dockerfiles/urdf_usd_converter.Dockerfile
+++ b/dockerfiles/urdf_usd_converter.Dockerfile
@@ -1,0 +1,17 @@
+# Builds a minimal rootfs containing urdf-usd-converter for use with the
+# bwrap-based urdf2usd wrapper. The filesystem of a container built from this
+# image is exported as a tarball by bin/build-and-release-urdf2usd.sh.
+#
+# This image is not intended to be run directly; the consumer extracts its
+# filesystem into /opt/urdf-usd-converter-rootfs/ and invokes the converter
+# via bwrap, so docker is only needed at build/publish time.
+
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
+
+ARG CONVERTER_VERSION
+RUN test -n "${CONVERTER_VERSION}" || { echo "CONVERTER_VERSION build-arg required" >&2; exit 1; } && \
+    pip install --no-cache-dir "urdf-usd-converter==${CONVERTER_VERSION}"
+
+# bwrap --bind requires mountpoints to exist in the target rootfs.
+RUN mkdir -p /cortex /workspace

--- a/docs/urdf2usd.md
+++ b/docs/urdf2usd.md
@@ -12,6 +12,8 @@ This package gives you a `urdf2usd` CLI on PATH that works the same way on
 
 ## Install on a running host (one-liner)
 
+Installs the latest published `urdf2usd-v*` release:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/main/bin/install-urdf2usd.sh | sudo bash
 ```
@@ -70,20 +72,22 @@ no docker, no daemon, and no separate install step.
 The rootfs tarball is built and uploaded as a GitHub Release asset by:
 
 ```bash
-bin/build-and-release-urdf2usd.sh <converter-version>
+bin/build-and-release-urdf2usd.sh                     # latest urdf-usd-converter on PyPI
+bin/build-and-release-urdf2usd.sh 0.1.3               # pinned converter version
 ```
 
-That script needs `docker`, `gh` (authenticated), `tar`, and `gzip` on the
-machine running it. It tags the release `urdf2usd-v<converter-version>` and
-uploads `urdf-usd-converter-rootfs-<version>.tar.gz` as an asset, producing a
-stable public URL of the form:
+That script needs `docker`, `gh` (authenticated), `tar`, `gzip`, `curl`, and
+`python3` on the machine running it. It tags the release
+`urdf2usd-v<converter-version>` and uploads
+`urdf-usd-converter-rootfs-<version>.tar.gz` as an asset, producing a stable
+public URL of the form:
 
 ```
 https://github.com/Extend-Robotics/er_build_tools/releases/download/urdf2usd-v<version>/urdf-usd-converter-rootfs-<version>.tar.gz
 ```
 
-After cutting the release, bump `DEFAULT_VERSION` in `bin/install-urdf2usd.sh`
-if you want the one-liner to pick it up by default.
+The installer auto-discovers the latest release via the GitHub API, so no
+follow-up edits are needed after a new release is cut.
 
 ## Why bwrap (not chroot, not docker)?
 

--- a/docs/urdf2usd.md
+++ b/docs/urdf2usd.md
@@ -1,0 +1,107 @@
+# urdf2usd
+
+Run [`urdf-usd-converter`](https://github.com/newton-physics/urdf-usd-converter)
+on a glibc-2.31 host (Ubuntu 20.04 / ROS Noetic) by sandboxing it under
+[`bwrap`](https://github.com/containers/bubblewrap) inside a pre-built
+glibc-2.36 rootfs.
+
+The converter wheel ships only `manylinux_2_35` binaries (it links against
+`GLIBC_2.34`/`GLIBC_2.35` symbols), so a native install fails on Ubuntu 20.04.
+This package gives you a `urdf2usd` CLI on PATH that works the same way on
+20.04 today and on 22.04+ tomorrow.
+
+## Install on a running host (one-liner)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/main/bin/install-urdf2usd.sh | sudo bash
+```
+
+To pin a specific converter version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/main/bin/install-urdf2usd.sh \
+    | sudo bash -s -- --version 0.1.3
+```
+
+The installer apt-installs `bubblewrap`, downloads the rootfs tarball from
+the matching GitHub Release, extracts it to `/opt/urdf-usd-converter-rootfs/`,
+and drops the `urdf2usd` wrapper at `/usr/local/bin/urdf2usd`.
+
+## Use
+
+```bash
+urdf2usd /path/to/robot.urdf /path/to/output_usd
+urdf2usd /path/to/robot.urdf /path/to/output_usd --package my_pkg=/path/to/my_pkg
+urdf2usd --help
+```
+
+The wrapper bind-mounts `/cortex`, `/home`, `/tmp`, `/var/tmp`, `/mnt`,
+`/media` into the sandbox, so absolute paths to inputs and output dirs under
+those roots Just Work. For inputs elsewhere, either edit the bind list at the
+top of `bin/urdf2usd` or symlink into one of the bound roots.
+
+## Bake into a Docker image at build time (no install step at runtime)
+
+If you're building an image (e.g. a Noetic robot image) and want `urdf2usd`
+baked in, use a multi-stage build to copy the converter rootfs in directly.
+This avoids the runtime download entirely.
+
+```dockerfile
+# Stage 1: build the converter rootfs
+FROM python:3.12-slim AS urdf_usd_rootfs
+ARG CONVERTER_VERSION=0.1.3
+RUN pip install --no-cache-dir "urdf-usd-converter==${CONVERTER_VERSION}" \
+    && mkdir -p /cortex
+
+# Stage 2: your image
+FROM <your-base-image>
+
+COPY --from=urdf_usd_rootfs / /opt/urdf-usd-converter-rootfs/
+RUN apt-get update && apt-get install -y bubblewrap && rm -rf /var/lib/apt/lists/*
+ADD https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/main/bin/urdf2usd /usr/local/bin/urdf2usd
+RUN chmod +x /usr/local/bin/urdf2usd
+```
+
+`urdf2usd` is then on PATH in the resulting image with no runtime download,
+no docker, no daemon, and no separate install step.
+
+## Cutting a new release
+
+The rootfs tarball is built and uploaded as a GitHub Release asset by:
+
+```bash
+bin/build-and-release-urdf2usd.sh <converter-version>
+```
+
+That script needs `docker`, `gh` (authenticated), `tar`, and `gzip` on the
+machine running it. It tags the release `urdf2usd-v<converter-version>` and
+uploads `urdf-usd-converter-rootfs-<version>.tar.gz` as an asset, producing a
+stable public URL of the form:
+
+```
+https://github.com/Extend-Robotics/er_build_tools/releases/download/urdf2usd-v<version>/urdf-usd-converter-rootfs-<version>.tar.gz
+```
+
+After cutting the release, bump `DEFAULT_VERSION` in `bin/install-urdf2usd.sh`
+if you want the one-liner to pick it up by default.
+
+## Why bwrap (not chroot, not docker)?
+
+- **`chroot`** needs root, doesn't isolate processes/IPC/network, and won't
+  set up a `/proc` or `/dev` for you. Bwrap is a thin layer on top of Linux
+  user namespaces that handles all of that and runs unprivileged.
+- **`docker run`** needs a daemon at runtime. The whole reason this exists
+  is that the consumer container (Noetic) doesn't ship docker.
+
+## Migration to glibc 2.35+ (Ubuntu 22.04+, Debian bookworm+)
+
+On a host where the converter installs natively, you can drop bwrap entirely:
+
+```bash
+pip install urdf-usd-converter
+```
+
+This installs the `urdf_usd_converter` binary on PATH. At that point you can
+remove `/opt/urdf-usd-converter-rootfs/` and `/usr/local/bin/urdf2usd` (or
+keep the wrapper as a stable alias and change its body to `exec urdf_usd_converter "$@"`).
+Caller code that invokes `urdf2usd …` keeps working unchanged.


### PR DESCRIPTION
## Summary

Adds a `urdf2usd` CLI to `er_build_tools` that runs [`urdf-usd-converter`](https://github.com/newton-physics/urdf-usd-converter) on a glibc-2.31 host (Ubuntu 20.04 / ROS Noetic) by sandboxing it under `bwrap` inside a pre-built glibc-2.36 rootfs. The converter's transitive dep `usd-exchange` ships only `manylinux_2_35` wheels, so a native `pip install urdf-usd-converter` fails on 20.04.

## What's in here

- `bin/build-and-release-urdf2usd.sh` — maintainer tool. Builds a `python:3.12-slim` image with `urdf-usd-converter==<version>` installed, exports the filesystem as a gzip tarball, computes its sha256, and uploads tarball + sha256 + wrapper as assets on a GitHub Release tagged `urdf2usd-v<version>`.
- `bin/install-urdf2usd.sh` — consumer-side installer. Downloads the tarball + sha256, verifies the checksum, extracts to a staging dir, and atomically swaps into `/opt/urdf-usd-converter-rootfs/` (existing install is preserved if extraction fails). Apt-installs `bubblewrap`, drops the wrapper at `/usr/local/bin/urdf2usd`. Documented invocation: `curl -fsSL …/install-urdf2usd.sh | sudo bash`.
- `bin/urdf2usd` — runtime wrapper. `exec bwrap --ro-bind <rootfs> / --bind /cortex /cortex … /usr/local/bin/urdf_usd_converter "$@"`. No docker daemon needed at runtime.
- `dockerfiles/urdf_usd_converter.Dockerfile` — build recipe (`python:3.12-slim` + pinned pip install).
- `docs/urdf2usd.md` — install / use / multi-stage-bake / migration docs.

## Security caveat

The documented install path is `curl … | sudo bash`. The downloaded tarball is verified by sha256 against a sibling asset on the same Release, but anyone with write access to this repo's releases gets root on every install host. Treat that access as a privileged credential.

## Migration off the wrapper

When the host moves to Ubuntu 22.04+ (glibc 2.35+), `pip install urdf-usd-converter` works natively. The wrapper can be removed, or kept as a thin alias (`exec urdf_usd_converter "\$@"`) so callers keep working unchanged.

## Test plan

- [x] Build rootfs from the Dockerfile, extract via \`docker export | gzip\`, run the wrapper against an example URDF on Ubuntu 20.04 — verified produces a valid USD.
- [ ] End-to-end on a target Noetic host: \`build-and-release-urdf2usd.sh <ver> --repo <fork>\` → \`install-urdf2usd.sh --version <ver> --repo <fork>\` → real URDF→USD conversion with output under \`/cortex\`.
- [ ] Confirm \`check_bash.yml\` passes (the three new bash files carry \`# SKIP_CHECK\` so the workflow does not source-execute them).