### PR TITLE
Usb camera healthcheck

### DIFF
--- a/.github/workflows/check_camera_healthcheck.yml
+++ b/.github/workflows/check_camera_healthcheck.yml
@@ -9,6 +9,10 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v4
 
+      - name: shellcheck usb-camera-healthcheck
+        shell: bash
+        run: shellcheck bin/usb-camera-healthcheck.sh
+
       - name: run usb-camera-healthcheck tests
         shell: bash
         run: bash tests/test_usb_camera_healthcheck.sh

--- a/.github/workflows/check_camera_healthcheck.yml
+++ b/.github/workflows/check_camera_healthcheck.yml
@@ -1,0 +1,14 @@
+name: Check camera healthcheck
+
+on: [push]
+
+jobs:
+  test_camera_healthcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v4
+
+      - name: run usb-camera-healthcheck tests
+        shell: bash
+        run: bash tests/test_usb_camera_healthcheck.sh

--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -208,7 +208,17 @@ update_helper_bash_functions() {
 }
 
 er_usb_camera_healthcheck() {
-    bash <(curl -Ls https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/bin/usb-camera-healthcheck.sh) "$@"
+    local script_path exit_code
+    script_path="$(mktemp)" || return 1
+    if ! curl -fsSL "https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/${THIS_SCRIPT_BRANCH}/bin/usb-camera-healthcheck.sh" -o "$script_path"; then
+        echo "ERROR: failed to fetch usb-camera-healthcheck.sh" >&2
+        rm -f "$script_path"
+        return 1
+    fi
+    bash "$script_path" "$@"
+    exit_code=$?
+    rm -f "$script_path"
+    return "$exit_code"
 }
 
 # python linters

--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -209,6 +209,10 @@ update_helper_bash_functions() {
 
 er_usb_camera_healthcheck() {
     local script_path exit_code
+    if [ -z "${THIS_SCRIPT_BRANCH:-}" ]; then
+        echo "ERROR: THIS_SCRIPT_BRANCH is unset; cannot determine which branch to fetch" >&2
+        return 1
+    fi
     script_path="$(mktemp)" || return 1
     if ! curl -fsSL "https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/${THIS_SCRIPT_BRANCH}/bin/usb-camera-healthcheck.sh" -o "$script_path"; then
         echo "ERROR: failed to fetch usb-camera-healthcheck.sh" >&2

--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -207,6 +207,10 @@ update_helper_bash_functions() {
     echo -e "${Green}helper_bash_functions updated. Run 'source ~/.helper_bash_functions' to reload.${Color_Off}"
 }
 
+er_usb_camera_healthcheck() {
+    bash <(curl -Ls https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/bin/usb-camera-healthcheck.sh) "$@"
+}
+
 # python linters
 LINTER_VERSIONS_URL="https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/${THIS_SCRIPT_BRANCH}/linter_versions.env"
 LINTER_MAX_LINE_LENGTH="140"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # er_build_tools
+
+## Tools
+
+- [usb-camera-healthcheck](docs/usb-camera-healthcheck.md) — report USB link speed + verdict for every UVC camera (sysfs only, no root, curl-bash).
+- [urdf2usd](docs/urdf2usd.md) — URDF → USD converter.

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -50,6 +50,14 @@ is_camera() {
   return 1
 }
 
+lookup_model() {
+  case "$1" in
+    2bc5:066b) printf 'Femto Bolt|REQUIRES_USB3' ;;
+    2bc5:0803) printf 'Gemini 336|USB2_TOLERANT' ;;
+    *)         printf '' ;;
+  esac
+}
+
 parse_args() {
   while [ $# -gt 0 ]; do
     case "$1" in

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# SKIP_CHECK
 # usb-camera-healthcheck.sh — report negotiated USB link speed + a verdict for
 # every UVC camera on this host, using sysfs only (no lsusb/dmesg, no root).
 #
 # Verdict per camera:
 #   OK            linked at USB3 (>=5000 Mbps)
-#   OK (reduced)  linked at USB2 but the model is known to tolerate it
+#   OK (reduced)  linked at USB2 (480 Mbps) and the model is known to tolerate it
 #   WILL FAIL     linked below USB3 and the model REQUIRES USB3 (driver aborts)
-#   WARN          linked below USB3, requirement unknown
+#   WARN          linked below USB3 with requirement unknown, OR a known
+#                 USB2-tolerant model linked below USB2 (e.g. 12 Mbps)
 #
 # Needs no root. Run on a bare Jetson with:
 #   bash <(curl -Ls https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/bin/usb-camera-healthcheck.sh)
@@ -34,8 +34,8 @@ usage="Usage: usb-camera-healthcheck.sh [-w|--watch] [-i|--interval N] [-v|--ver
 
 read_attr() {
   local path="$1"
-  [ -e "$path" ] || { printf '' ; return 0; }
-  cat "$path" 2>/dev/null || printf ''
+  [ -e "$path" ] || { printf ''; return 0; }
+  cat "$path" || { echo "ERROR: failed to read $path" >&2; exit 3; }
 }
 
 setup_colors() {
@@ -56,11 +56,12 @@ parent_hub() {
 }
 
 is_camera() {
-  local dev_dir="$1" dev_name intf
+  local dev_dir="$1" dev_name interface_path interface_class
   dev_name="$(basename "$dev_dir")"
-  for intf in "${dev_dir}/${dev_name}":*; do
-    [ -e "$intf/bInterfaceClass" ] || continue
-    [ "$(cat "$intf/bInterfaceClass" 2>/dev/null)" = "0e" ] && return 0
+  for interface_path in "${dev_dir}/${dev_name}":*; do
+    [ -e "$interface_path/bInterfaceClass" ] || continue
+    interface_class="$(read_attr "$interface_path/bInterfaceClass")" || exit 3
+    [ "$interface_class" = "0e" ] && return 0
   done
   return 1
 }
@@ -86,55 +87,66 @@ verdict_for() {
   esac
 }
 
-# Each CAMERA_ROWS entry is field_sep-joined: name|vidpid|speed|requirement|model|product|parent|verdict
-# (kept in sync with the IFS="$field_sep" read sites in compute_exit_code, any_problem, render_report)
+# Each CAMERA_ROWS entry is field_sep-joined: name|vidpid|speed|requirement|model|product|parent
+# Verdict is derived (never stored) via verdict_for at each read site, so it cannot drift from
+# speed/requirement. Field order is kept in sync with the IFS="$field_sep" read sites in
+# compute_exit_code, any_problem, render_report.
 scan_cameras() {
   CAMERA_ROWS=()
-  local dev_dir name vid pid vidpid speed product parent entry model requirement verdict
+  local dev_dir name vid pid vidpid speed product parent entry model requirement
   for dev_dir in "$SYSFS_USB_ROOT"/*; do
     [ -e "$dev_dir/speed" ] || continue
     is_camera "$dev_dir" || continue
     name="$(basename "$dev_dir")"
     vid="$(read_attr "$dev_dir/idVendor")"
     pid="$(read_attr "$dev_dir/idProduct")"
+    if [ -z "$vid" ] || [ -z "$pid" ]; then
+      echo "ERROR: unreadable USB vendor/product id for $name (got '${vid}:${pid}')" >&2
+      exit 3
+    fi
     vidpid="${vid}:${pid}"
     speed="$(read_attr "$dev_dir/speed")"
+    case "$speed" in
+      ''|*[!0-9]*)
+        echo "ERROR: unreadable or non-numeric USB speed '$speed' for $name" >&2
+        exit 3
+        ;;
+    esac
     product="$(read_attr "$dev_dir/product")"
     parent="$(parent_hub "$name")"
     entry="$(lookup_model "$vidpid")"
     if [ -n "$entry" ]; then
-      model="${entry%%|*}"
+      model="${entry%|*}"
       requirement="${entry##*|}"
     else
       model="?"
       requirement=""
     fi
-    if [ -z "$speed" ]; then
-      echo "ERROR: unreadable USB speed for $name" >&2
-      exit 3
-    fi
-    verdict="$(verdict_for "$speed" "$requirement")"
-    CAMERA_ROWS+=("${name}${field_sep}${vidpid}${field_sep}${speed}${field_sep}${requirement}${field_sep}${model}${field_sep}${product}${field_sep}${parent}${field_sep}${verdict}")
+    CAMERA_ROWS+=("${name}${field_sep}${vidpid}${field_sep}${speed}${field_sep}${requirement}${field_sep}${model}${field_sep}${product}${field_sep}${parent}")
   done
 }
 
 compute_exit_code() {
   if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then printf '2'; return 0; fi
-  local worst=0 row requirement verdict
+  local worst=0 row speed requirement verdict
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS="$field_sep" read -r _ _ _ requirement _ _ _ verdict <<< "$row"
+    IFS="$field_sep" read -r _ _ speed requirement _ _ _ <<< "$row"
+    verdict="$(verdict_for "$speed" "$requirement")"
     case "$verdict" in
+      OK|OK_REDUCED) ;;
       WILL_FAIL) worst=1 ;;
       WARN) if [ -z "$requirement" ] && [ "$fail_on_unknown_usb2" = true ]; then worst=1; fi ;;
+      *) echo "ERROR: internal: unexpected verdict '$verdict'" >&2; exit 3 ;;
     esac
   done
   printf '%s' "$worst"
 }
 
 any_problem() {
-  local row verdict
+  local row speed requirement verdict
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS="$field_sep" read -r _ _ _ _ _ _ _ verdict <<< "$row"
+    IFS="$field_sep" read -r _ _ speed requirement _ _ _ <<< "$row"
+    verdict="$(verdict_for "$speed" "$requirement")"
     case "$verdict" in WILL_FAIL|WARN) return 0 ;; esac
   done
   return 1
@@ -144,13 +156,14 @@ render_report() {
   printf '%bUVC camera USB healthcheck%b\n' "$c_bold" "$c_reset"
   local row name vidpid speed requirement model product parent verdict label color shown
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS="$field_sep" read -r name vidpid speed requirement model product parent verdict <<< "$row"
+    IFS="$field_sep" read -r name vidpid speed requirement model product parent <<< "$row"
+    verdict="$(verdict_for "$speed" "$requirement")"
     case "$verdict" in
       OK)         label='OK (USB3)';               color="$c_green" ;;
       OK_REDUCED) label='OK (USB2, reduced spec)'; color="$c_green" ;;
       WILL_FAIL)  label='WILL FAIL';               color="$c_red" ;;
       WARN)       label='WARN: linked below USB3'; color="$c_yellow" ;;
-      *)          label="UNKNOWN VERDICT: $verdict"; color="$c_yellow" ;;
+      *)          echo "ERROR: internal: unexpected verdict '$verdict' for $name" >&2; exit 3 ;;
     esac
     shown="$model"
     [ "$model" = "?" ] && shown="$product"
@@ -182,29 +195,37 @@ EOF
 render_tree() {
   echo
   echo "Full USB device tree:"
-  local d
+  local d name vid pid speed device_class product
   for d in "$SYSFS_USB_ROOT"/*; do
     [ -e "$d/speed" ] || continue
+    name="$(basename "$d")"
+    vid="$(read_attr "$d/idVendor")"
+    pid="$(read_attr "$d/idProduct")"
+    speed="$(read_attr "$d/speed")"
+    device_class="$(read_attr "$d/bDeviceClass")"
+    product="$(read_attr "$d/product")"
     printf '  %-10s %-10s %6s Mbps  class=%-3s %s\n' \
-      "$(basename "$d")" \
-      "$(read_attr "$d/idVendor"):$(read_attr "$d/idProduct")" \
-      "$(read_attr "$d/speed")" \
-      "$(read_attr "$d/bDeviceClass")" \
-      "$(read_attr "$d/product")"
+      "$name" "${vid}:${pid}" "$speed" "$device_class" "$product"
   done | sort
+}
+
+render_output() {
+  if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then
+    echo "No USB cameras (UVC devices) found."
+  else
+    render_report
+    any_problem && print_remediation
+  fi
+  if [ "$verbose" = true ]; then
+    render_tree
+  fi
 }
 
 watch_loop() {
   while true; do
     printf '\033[H\033[2J'
     scan_cameras
-    if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then
-      echo "No USB cameras (UVC devices) found."
-    else
-      render_report
-      any_problem && print_remediation
-    fi
-    [ "$verbose" = true ] && render_tree
+    render_output
     printf '\n(refresh %ss — Ctrl-C to exit)\n' "$watch_interval"
     sleep "$watch_interval"
   done
@@ -215,13 +236,7 @@ run_once() {
   local code
   code="$(compute_exit_code)"
   if [ "$quiet" != true ]; then
-    if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then
-      echo "No USB cameras (UVC devices) found."
-    else
-      render_report
-      any_problem && print_remediation
-    fi
-    [ "$verbose" = true ] && render_tree
+    render_output
   fi
   exit "$code"
 }

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -86,6 +86,8 @@ verdict_for() {
   esac
 }
 
+# Each CAMERA_ROWS entry is field_sep-joined: name|vidpid|speed|requirement|model|product|parent|verdict
+# (kept in sync with the IFS="$field_sep" read sites in compute_exit_code, any_problem, render_report)
 scan_cameras() {
   CAMERA_ROWS=()
   local dev_dir name vid pid vidpid speed product parent entry model requirement verdict
@@ -148,12 +150,15 @@ render_report() {
       OK_REDUCED) label='OK (USB2, reduced spec)'; color="$c_green" ;;
       WILL_FAIL)  label='WILL FAIL';               color="$c_red" ;;
       WARN)       label='WARN: linked below USB3'; color="$c_yellow" ;;
+      *)          label="UNKNOWN VERDICT: $verdict"; color="$c_yellow" ;;
     esac
     shown="$model"
     [ "$model" = "?" ] && shown="$product"
     [ -n "$shown" ] && [ "$shown" != "?" ] || shown="$vidpid"
-    printf '  %b%-28s%b %5s Mbps  %b%-26s%b  [%s on %s]\n' \
-      "$c_bold" "$shown" "$c_reset" "$speed" "$color" "$label" "$c_reset" "$vidpid" "$parent"
+    local location="$vidpid"
+    [ -n "$parent" ] && location="$vidpid on $parent"
+    printf '  %b%-28s%b %5s Mbps  %b%-26s%b  [%s]\n' \
+      "$c_bold" "$shown" "$c_reset" "$speed" "$color" "$label" "$c_reset" "$location"
   done
 }
 

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -26,7 +26,7 @@ field_sep=$'\x1f'
 
 fail_on_unknown_usb2=false
 watch_mode=false
-watch_interval=1
+watch_interval=5
 verbose=false
 quiet=false
 

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -71,6 +71,54 @@ verdict_for() {
   esac
 }
 
+scan_cameras() {
+  CAMERA_ROWS=()
+  local dev_dir name vid pid vidpid speed product parent entry model requirement verdict
+  for dev_dir in "$SYSFS_USB_ROOT"/*; do
+    [ -e "$dev_dir/speed" ] || continue
+    is_camera "$dev_dir" || continue
+    name="$(basename "$dev_dir")"
+    vid="$(read_attr "$dev_dir/idVendor")"
+    pid="$(read_attr "$dev_dir/idProduct")"
+    vidpid="${vid}:${pid}"
+    speed="$(read_attr "$dev_dir/speed")"
+    product="$(read_attr "$dev_dir/product")"
+    parent="$(parent_hub "$name")"
+    entry="$(lookup_model "$vidpid")"
+    if [ -n "$entry" ]; then
+      model="${entry%%|*}"
+      requirement="${entry##*|}"
+    else
+      model="?"
+      requirement=""
+    fi
+    if [ -z "$speed" ]; then
+      echo "ERROR: unreadable USB speed for $name" >&2
+      exit 3
+    fi
+    verdict="$(verdict_for "$speed" "$requirement")"
+    CAMERA_ROWS+=("$(printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s' \
+      "$name" "$vidpid" "$speed" "$requirement" "$model" "$product" "$parent" "$verdict")")
+  done
+}
+
+compute_exit_code() {
+  if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then printf '2'; return 0; fi
+  local worst=0 row verdict
+  for row in "${CAMERA_ROWS[@]}"; do
+    IFS=$'\t' read -r _ _ _ _ _ _ _ verdict <<< "$row"
+    [ "$verdict" = "WILL_FAIL" ] && worst=1
+  done
+  printf '%s' "$worst"
+}
+
+run_once() {
+  scan_cameras
+  local code
+  code="$(compute_exit_code)"
+  exit "$code"
+}
+
 parse_args() {
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -99,6 +147,8 @@ parse_args() {
 
 main() {
   parse_args "$@"
+  [ -d "$SYSFS_USB_ROOT" ] || { echo "ERROR: USB sysfs path not found: $SYSFS_USB_ROOT" >&2; exit 3; }
+  run_once
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -18,6 +18,12 @@ set -euo pipefail
 
 : "${SYSFS_USB_ROOT:=/sys/bus/usb/devices}"
 
+# Non-whitespace TSV delimiter (ASCII Unit Separator). Chosen so that empty
+# fields (e.g. a root-port camera's empty parent) are not collapsed by `read`,
+# which drops empty whitespace-delimited fields. It cannot appear in any sysfs
+# string (device name, vid:pid, speed, model/product name).
+field_sep=$'\x1f'
+
 fail_on_unknown_usb2=false
 watch_mode=false
 watch_interval=1
@@ -99,15 +105,14 @@ scan_cameras() {
       requirement="${entry##*|}"
     else
       model="?"
-      requirement="UNKNOWN"
+      requirement=""
     fi
     if [ -z "$speed" ]; then
       echo "ERROR: unreadable USB speed for $name" >&2
       exit 3
     fi
     verdict="$(verdict_for "$speed" "$requirement")"
-    CAMERA_ROWS+=("$(printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s' \
-      "$name" "$vidpid" "$speed" "$requirement" "$model" "$product" "$parent" "$verdict")")
+    CAMERA_ROWS+=("${name}${field_sep}${vidpid}${field_sep}${speed}${field_sep}${requirement}${field_sep}${model}${field_sep}${product}${field_sep}${parent}${field_sep}${verdict}")
   done
 }
 
@@ -115,10 +120,10 @@ compute_exit_code() {
   if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then printf '2'; return 0; fi
   local worst=0 row requirement verdict
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS=$'\t' read -r _ _ _ requirement _ _ _ verdict <<< "$row"
+    IFS="$field_sep" read -r _ _ _ requirement _ _ _ verdict <<< "$row"
     case "$verdict" in
       WILL_FAIL) worst=1 ;;
-      WARN) if [ "$requirement" = "UNKNOWN" ] && [ "$fail_on_unknown_usb2" = true ]; then worst=1; fi ;;
+      WARN) if [ -z "$requirement" ] && [ "$fail_on_unknown_usb2" = true ]; then worst=1; fi ;;
     esac
   done
   printf '%s' "$worst"
@@ -127,7 +132,7 @@ compute_exit_code() {
 any_problem() {
   local row verdict
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS=$'\t' read -r _ _ _ _ _ _ _ verdict <<< "$row"
+    IFS="$field_sep" read -r _ _ _ _ _ _ _ verdict <<< "$row"
     case "$verdict" in WILL_FAIL|WARN) return 0 ;; esac
   done
   return 1
@@ -137,7 +142,7 @@ render_report() {
   printf '%bUVC camera USB healthcheck%b\n' "$c_bold" "$c_reset"
   local row name vidpid speed requirement model product parent verdict label color shown
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS=$'\t' read -r name vidpid speed requirement model product parent verdict <<< "$row"
+    IFS="$field_sep" read -r name vidpid speed requirement model product parent verdict <<< "$row"
     case "$verdict" in
       OK)         label='OK (USB3)';               color="$c_green" ;;
       OK_REDUCED) label='OK (USB2, reduced spec)'; color="$c_green" ;;

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -58,6 +58,19 @@ lookup_model() {
   esac
 }
 
+verdict_for() {
+  local speed="$1" requirement="$2"
+  if [ "$speed" -ge 5000 ]; then
+    printf 'OK'
+    return 0
+  fi
+  case "$requirement" in
+    REQUIRES_USB3) printf 'WILL_FAIL' ;;
+    USB2_TOLERANT) if [ "$speed" -eq 480 ]; then printf 'OK_REDUCED'; else printf 'WARN'; fi ;;
+    *)             printf 'WARN' ;;
+  esac
+}
+
 parse_args() {
   while [ $# -gt 0 ]; do
     case "$1" in

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -32,6 +32,15 @@ read_attr() {
   cat "$path" 2>/dev/null || printf ''
 }
 
+setup_colors() {
+  if [ -t 1 ]; then
+    c_red=$'\033[31m'; c_yellow=$'\033[33m'; c_green=$'\033[32m'
+    c_bold=$'\033[1m'; c_reset=$'\033[0m'
+  else
+    c_red=''; c_yellow=''; c_green=''; c_bold=''; c_reset=''
+  fi
+}
+
 parent_hub() {
   local name="$1"
   case "$name" in
@@ -112,10 +121,63 @@ compute_exit_code() {
   printf '%s' "$worst"
 }
 
+any_problem() {
+  local row verdict
+  for row in "${CAMERA_ROWS[@]}"; do
+    IFS=$'\t' read -r _ _ _ _ _ _ _ verdict <<< "$row"
+    case "$verdict" in WILL_FAIL|WARN) return 0 ;; esac
+  done
+  return 1
+}
+
+render_report() {
+  printf '%bUVC camera USB healthcheck%b\n' "$c_bold" "$c_reset"
+  local row name vidpid speed requirement model product parent verdict label color shown
+  for row in "${CAMERA_ROWS[@]}"; do
+    IFS=$'\t' read -r name vidpid speed requirement model product parent verdict <<< "$row"
+    case "$verdict" in
+      OK)         label='OK (USB3)';               color="$c_green" ;;
+      OK_REDUCED) label='OK (USB2, reduced spec)'; color="$c_green" ;;
+      WILL_FAIL)  label='WILL FAIL';               color="$c_red" ;;
+      WARN)       label='WARN: linked below USB3'; color="$c_yellow" ;;
+    esac
+    shown="$model"
+    [ "$model" = "?" ] && shown="$product"
+    [ -n "$shown" ] && [ "$shown" != "?" ] || shown="$vidpid"
+    printf '  %b%-28s%b %5s Mbps  %b%-26s%b  [%s on %s]\n' \
+      "$c_bold" "$shown" "$c_reset" "$speed" "$color" "$label" "$c_reset" "$vidpid" "$parent"
+  done
+}
+
+print_remediation() {
+  cat <<'EOF'
+
+A camera is linked below USB3. To fix:
+  1. Try a known-good USB3 cable first. The fault almost always travels with
+     the cable (a USB2/charge-only or damaged cable falls back to 480 Mbps).
+  2. Combo-hub note: a USB3 hub shows TWO faces on the bus — a "USB 3.0 Hub"
+     and a "USB 2.0 Hub" (the same physical hub). A camera sitting under the
+     "USB 2.0 Hub" face does NOT mean the hub/port is USB2-only; it means that
+     camera linked at USB2. Do not blame the hub.
+  3. Isolation test: move the camera onto a known-good port + cable to prove
+     whether it is the cable or the camera.
+  4. The driver checks USB speed only at launch — restart the ROS stack after
+     fixing the cable, or the camera node will not come up.
+EOF
+}
+
 run_once() {
   scan_cameras
   local code
   code="$(compute_exit_code)"
+  if [ "$quiet" != true ]; then
+    if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then
+      echo "No USB cameras (UVC devices) found."
+    else
+      render_report
+      any_problem && print_remediation
+    fi
+  fi
   exit "$code"
 }
 
@@ -147,6 +209,7 @@ parse_args() {
 
 main() {
   parse_args "$@"
+  setup_colors
   [ -d "$SYSFS_USB_ROOT" ] || { echo "ERROR: USB sysfs path not found: $SYSFS_USB_ROOT" >&2; exit 3; }
   run_once
 }

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -99,7 +99,7 @@ scan_cameras() {
       requirement="${entry##*|}"
     else
       model="?"
-      requirement=""
+      requirement="UNKNOWN"
     fi
     if [ -z "$speed" ]; then
       echo "ERROR: unreadable USB speed for $name" >&2
@@ -113,10 +113,13 @@ scan_cameras() {
 
 compute_exit_code() {
   if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then printf '2'; return 0; fi
-  local worst=0 row verdict
+  local worst=0 row requirement verdict
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS=$'\t' read -r _ _ _ _ _ _ _ verdict <<< "$row"
-    [ "$verdict" = "WILL_FAIL" ] && worst=1
+    IFS=$'\t' read -r _ _ _ requirement _ _ _ verdict <<< "$row"
+    case "$verdict" in
+      WILL_FAIL) worst=1 ;;
+      WARN) if [ "$requirement" = "UNKNOWN" ] && [ "$fail_on_unknown_usb2" = true ]; then worst=1; fi ;;
+    esac
   done
   printf '%s' "$worst"
 }

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -166,6 +166,21 @@ A camera is linked below USB3. To fix:
 EOF
 }
 
+render_tree() {
+  echo
+  echo "Full USB device tree:"
+  local d
+  for d in "$SYSFS_USB_ROOT"/*; do
+    [ -e "$d/speed" ] || continue
+    printf '  %-10s %-10s %6s Mbps  class=%-3s %s\n' \
+      "$(basename "$d")" \
+      "$(read_attr "$d/idVendor"):$(read_attr "$d/idProduct")" \
+      "$(read_attr "$d/speed")" \
+      "$(read_attr "$d/bDeviceClass")" \
+      "$(read_attr "$d/product")"
+  done | sort
+}
+
 run_once() {
   scan_cameras
   local code
@@ -177,6 +192,7 @@ run_once() {
       render_report
       any_problem && print_remediation
     fi
+    [ "$verbose" = true ] && render_tree
   fi
   exit "$code"
 }

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -189,6 +189,22 @@ render_tree() {
   done | sort
 }
 
+watch_loop() {
+  while true; do
+    printf '\033[H\033[2J'
+    scan_cameras
+    if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then
+      echo "No USB cameras (UVC devices) found."
+    else
+      render_report
+      any_problem && print_remediation
+    fi
+    [ "$verbose" = true ] && render_tree
+    printf '\n(refresh %ss — Ctrl-C to exit)\n' "$watch_interval"
+    sleep "$watch_interval"
+  done
+}
+
 run_once() {
   scan_cameras
   local code
@@ -235,6 +251,9 @@ main() {
   parse_args "$@"
   setup_colors
   [ -d "$SYSFS_USB_ROOT" ] || { echo "ERROR: USB sysfs path not found: $SYSFS_USB_ROOT" >&2; exit 3; }
+  if [ "$watch_mode" = true ]; then
+    watch_loop
+  fi
   run_once
 }
 

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -26,6 +26,20 @@ quiet=false
 
 usage="Usage: usb-camera-healthcheck.sh [-w|--watch] [-i|--interval N] [-v|--verbose] [-q|--quiet] [-s|--strict] [-h|--help]"
 
+read_attr() {
+  local path="$1"
+  [ -e "$path" ] || { printf '' ; return 0; }
+  cat "$path" 2>/dev/null || printf ''
+}
+
+parent_hub() {
+  local name="$1"
+  case "$name" in
+    *.*) printf '%s' "${name%.*}" ;;
+    *)   printf '' ;;
+  esac
+}
+
 parse_args() {
   while [ $# -gt 0 ]; do
     case "$1" in

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -5,9 +5,10 @@
 # Verdict per camera:
 #   OK            linked at USB3 (>=5000 Mbps)
 #   OK (reduced)  linked at USB2 (480 Mbps) and the model is known to tolerate it
-#   WILL FAIL     linked below USB3 and the model REQUIRES USB3 (driver aborts)
-#   WARN          linked below USB3 with requirement unknown, OR a known
-#                 USB2-tolerant model linked below USB2 (e.g. 12 Mbps)
+#   WILL FAIL     linked below the model's required link (driver aborts): a model
+#                 that REQUIRES USB3 linked below USB3, or a known USB2-tolerant
+#                 model linked below USB2 (e.g. 12 Mbps)
+#   WARN          linked below USB3 with requirement unknown
 #
 # Needs no root. Run on a bare Jetson with:
 #   bash <(curl -Ls https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/bin/usb-camera-healthcheck.sh)
@@ -60,7 +61,7 @@ is_camera() {
   dev_name="$(basename "$dev_dir")"
   for interface_path in "${dev_dir}/${dev_name}":*; do
     [ -e "$interface_path/bInterfaceClass" ] || continue
-    interface_class="$(read_attr "$interface_path/bInterfaceClass")" || exit 3
+    interface_class="$(read_attr "$interface_path/bInterfaceClass")"
     [ "$interface_class" = "0e" ] && return 0
   done
   return 1
@@ -82,20 +83,23 @@ verdict_for() {
   fi
   case "$requirement" in
     REQUIRES_USB3) printf 'WILL_FAIL' ;;
-    USB2_TOLERANT) if [ "$speed" -eq 480 ]; then printf 'OK_REDUCED'; else printf 'WARN'; fi ;;
+    USB2_TOLERANT) if [ "$speed" -ge 480 ]; then printf 'OK_REDUCED'; else printf 'WILL_FAIL'; fi ;;
     *)             printf 'WARN' ;;
   esac
 }
 
 # Each CAMERA_ROWS entry is field_sep-joined: name|vidpid|speed|requirement|model|product|parent
-# Verdict is derived (never stored) via verdict_for at each read site, so it cannot drift from
-# speed/requirement. Field order is kept in sync with the IFS="$field_sep" read sites in
-# compute_exit_code, any_problem, render_report.
+# Verdict is derived (never stored) via verdict_for, so it cannot drift from speed/requirement.
+# Every site that unpacks a row with `IFS="$field_sep" read` must use this exact field order
+# (row_verdict and render_report).
 scan_cameras() {
   CAMERA_ROWS=()
   local dev_dir name vid pid vidpid speed product parent entry model requirement
   for dev_dir in "$SYSFS_USB_ROOT"/*; do
-    [ -e "$dev_dir/speed" ] || continue
+    # Filter by the actual predicate (is this a UVC camera?), not by the presence
+    # of an attribute we later read. Gating on speed/idVendor presence would
+    # silently drop a camera missing that attribute; instead a confirmed camera
+    # with an unreadable speed or id reaches the fail-fast checks below.
     is_camera "$dev_dir" || continue
     name="$(basename "$dev_dir")"
     vid="$(read_attr "$dev_dir/idVendor")"
@@ -126,16 +130,26 @@ scan_cameras() {
   done
 }
 
+# Parse one CAMERA_ROWS entry and print its derived verdict. The single
+# field_sep read site shared by compute_exit_code and any_problem.
+row_verdict() {
+  local speed requirement
+  IFS="$field_sep" read -r _ _ speed requirement _ _ _ <<< "$1"
+  verdict_for "$speed" "$requirement"
+}
+
 compute_exit_code() {
   if [ "${#CAMERA_ROWS[@]}" -eq 0 ]; then printf '2'; return 0; fi
-  local worst=0 row speed requirement verdict
+  local worst=0 row verdict
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS="$field_sep" read -r _ _ speed requirement _ _ _ <<< "$row"
-    verdict="$(verdict_for "$speed" "$requirement")"
+    verdict="$(row_verdict "$row")"
+    # WARN only arises when a camera's requirement is unknown (verdict_for maps
+    # every known requirement to OK/OK_REDUCED/WILL_FAIL), so --strict escalates
+    # exactly the unknown-camera-below-USB3 case here.
     case "$verdict" in
       OK|OK_REDUCED) ;;
       WILL_FAIL) worst=1 ;;
-      WARN) if [ -z "$requirement" ] && [ "$fail_on_unknown_usb2" = true ]; then worst=1; fi ;;
+      WARN) if [ "$fail_on_unknown_usb2" = true ]; then worst=1; fi ;;
       *) echo "ERROR: internal: unexpected verdict '$verdict'" >&2; exit 3 ;;
     esac
   done
@@ -143,11 +157,14 @@ compute_exit_code() {
 }
 
 any_problem() {
-  local row speed requirement verdict
+  local row verdict
   for row in "${CAMERA_ROWS[@]}"; do
-    IFS="$field_sep" read -r _ _ speed requirement _ _ _ <<< "$row"
-    verdict="$(verdict_for "$speed" "$requirement")"
-    case "$verdict" in WILL_FAIL|WARN) return 0 ;; esac
+    verdict="$(row_verdict "$row")"
+    case "$verdict" in
+      WILL_FAIL|WARN) return 0 ;;
+      OK|OK_REDUCED) ;;
+      *) echo "ERROR: internal: unexpected verdict '$verdict'" >&2; exit 3 ;;
+    esac
   done
   return 1
 }
@@ -180,7 +197,7 @@ print_remediation() {
 
 A camera is linked below USB3. To fix:
   1. Try a known-good USB3 cable first. The fault almost always travels with
-     the cable (a USB2/charge-only or damaged cable falls back to 480 Mbps).
+     the cable (a USB2/charge-only or damaged cable drops to a slower link).
   2. Combo-hub note: a USB3 hub shows TWO faces on the bus — a "USB 3.0 Hub"
      and a "USB 2.0 Hub" (the same physical hub). A camera sitting under the
      "USB 2.0 Hub" face does NOT mean the hub/port is USB2-only; it means that

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# SKIP_CHECK
+# usb-camera-healthcheck.sh — report negotiated USB link speed + a verdict for
+# every UVC camera on this host, using sysfs only (no lsusb/dmesg, no root).
+#
+# Verdict per camera:
+#   OK            linked at USB3 (>=5000 Mbps)
+#   OK (reduced)  linked at USB2 but the model is known to tolerate it
+#   WILL FAIL     linked below USB3 and the model REQUIRES USB3 (driver aborts)
+#   WARN          linked below USB3, requirement unknown
+#
+# Needs no root. Run on a bare Jetson with:
+#   bash <(curl -Ls https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/bin/usb-camera-healthcheck.sh)
+# Or watch live while swapping cables:
+#   bash <(curl -Ls .../usb-camera-healthcheck.sh) --watch
+
+set -euo pipefail
+
+: "${SYSFS_USB_ROOT:=/sys/bus/usb/devices}"
+
+fail_on_unknown_usb2=false
+watch_mode=false
+watch_interval=1
+verbose=false
+quiet=false
+
+usage="Usage: usb-camera-healthcheck.sh [-w|--watch] [-i|--interval N] [-v|--verbose] [-q|--quiet] [-s|--strict] [-h|--help]"
+
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -w|--watch)   watch_mode=true; shift ;;
+      -i|--interval)
+        watch_interval="${2:-}"
+        case "$watch_interval" in
+          ''|*[!0-9]*) echo "ERROR: --interval needs a positive integer" >&2; exit 1 ;;
+        esac
+        [ "$watch_interval" -ge 1 ] || { echo "ERROR: --interval must be >= 1" >&2; exit 1; }
+        shift 2 ;;
+      -v|--verbose) verbose=true; shift ;;
+      -q|--quiet)   quiet=true; shift ;;
+      -s|--strict)  fail_on_unknown_usb2=true; shift ;;
+      -h|--help)    echo "$usage"; exit 0 ;;
+      *) echo "ERROR: Unknown option: $1" >&2; exit 1 ;;
+    esac
+  done
+  if [ "$quiet" = true ] && [ "$watch_mode" = true ]; then
+    echo "ERROR: --quiet and --watch are mutually exclusive" >&2; exit 1
+  fi
+  if [ "$quiet" = true ] && [ "$verbose" = true ]; then
+    echo "ERROR: --quiet and --verbose are mutually exclusive" >&2; exit 1
+  fi
+}
+
+main() {
+  parse_args "$@"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/bin/usb-camera-healthcheck.sh
+++ b/bin/usb-camera-healthcheck.sh
@@ -40,6 +40,16 @@ parent_hub() {
   esac
 }
 
+is_camera() {
+  local dev_dir="$1" dev_name intf
+  dev_name="$(basename "$dev_dir")"
+  for intf in "${dev_dir}/${dev_name}":*; do
+    [ -e "$intf/bInterfaceClass" ] || continue
+    [ "$(cat "$intf/bInterfaceClass" 2>/dev/null)" = "0e" ] && return 0
+  done
+  return 1
+}
+
 parse_args() {
   while [ $# -gt 0 ]; do
     case "$1" in

--- a/docs/usb-camera-healthcheck.md
+++ b/docs/usb-camera-healthcheck.md
@@ -3,7 +3,9 @@
 Reports the negotiated USB link speed and a verdict for every UVC camera on the
 host, using sysfs only — no `lsusb`, no `dmesg`, no root, identical on any
 Ubuntu/Jetson. Built to diagnose Orbbec depth cameras that silently fall back to
-USB2 (see `camera-usb-link-speed-healthcheck-handover.md` for the root cause).
+USB2: a USB3-required camera (e.g. the Femto Bolt) that negotiates only a USB2
+link — usually a bad or charge-only cable — aborts at driver init and never comes
+up.
 
 ## Run it (curl-bash, no install)
 

--- a/docs/usb-camera-healthcheck.md
+++ b/docs/usb-camera-healthcheck.md
@@ -1,0 +1,54 @@
+# usb-camera-healthcheck
+
+Reports the negotiated USB link speed and a verdict for every UVC camera on the
+host, using sysfs only — no `lsusb`, no `dmesg`, no root, identical on any
+Ubuntu/Jetson. Built to diagnose Orbbec depth cameras that silently fall back to
+USB2 (see `camera-usb-link-speed-healthcheck-handover.md` for the root cause).
+
+## Run it (curl-bash, no install)
+
+    bash <(curl -Ls https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/bin/usb-camera-healthcheck.sh)
+
+Watch live while swapping cables until the link is USB3:
+
+    bash <(curl -Ls .../usb-camera-healthcheck.sh) --watch
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `-w`, `--watch` | Clear-screen redraw every interval until Ctrl-C |
+| `-i N`, `--interval N` | Watch refresh seconds (default 1) |
+| `-v`, `--verbose` | Also print the full USB device tree |
+| `-q`, `--quiet` | No output; verdict via exit code only |
+| `-s`, `--strict` | Treat unknown cameras linked below USB3 as failure |
+| `-h`, `--help` | Usage |
+
+`--quiet` cannot combine with `--watch` or `--verbose`.
+
+## Verdicts
+
+| Link | Known REQUIRES_USB3 | Known USB2-tolerant | Unknown camera |
+|------|---------------------|---------------------|----------------|
+| USB3 (≥5000) | OK | OK | OK |
+| USB2 (480) | WILL FAIL | OK (reduced spec) | WARN |
+| USB1 (12) | WILL FAIL | WARN | WARN |
+
+A `WILL FAIL` camera (e.g. Femto Bolt on USB2) aborts at driver init — fix the
+cable and restart the ROS stack.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All cameras OK (or warnings only, without `--strict`) |
+| 1 | A REQUIRES_USB3 camera below USB3, or `--strict` and an unknown camera below USB3 |
+| 2 | No cameras found |
+| 3 | Tool/sysfs error |
+
+## Adding a camera model
+
+Edit the `lookup_model` table in `bin/usb-camera-healthcheck.sh` — one `case`
+line per `vid:pid`, mapping to `<name>|REQUIRES_USB3` or `<name>|USB2_TOLERANT`.
+Detection itself is generic (USB Video Class), so unknown cameras are still
+reported; the table only sharpens the verdict.

--- a/docs/usb-camera-healthcheck.md
+++ b/docs/usb-camera-healthcheck.md
@@ -48,6 +48,9 @@ cable and restart the ROS stack.
 | 2 | No cameras found |
 | 3 | Tool/sysfs error |
 
+`--watch` runs until interrupted (Ctrl-C) and so does not follow this exit-code
+contract; use a one-shot run for scripting/CI.
+
 ## Adding a camera model
 
 Edit the `lookup_model` table in `bin/usb-camera-healthcheck.sh` — one `case`

--- a/docs/usb-camera-healthcheck.md
+++ b/docs/usb-camera-healthcheck.md
@@ -18,7 +18,7 @@ Watch live while swapping cables until the link is USB3:
 | Flag | Effect |
 |------|--------|
 | `-w`, `--watch` | Clear-screen redraw every interval until Ctrl-C |
-| `-i N`, `--interval N` | Watch refresh seconds (default 1) |
+| `-i N`, `--interval N` | Watch refresh seconds (default 5) |
 | `-v`, `--verbose` | Also print the full USB device tree |
 | `-q`, `--quiet` | No output; verdict via exit code only |
 | `-s`, `--strict` | Treat unknown cameras linked below USB3 as failure |

--- a/docs/usb-camera-healthcheck.md
+++ b/docs/usb-camera-healthcheck.md
@@ -34,10 +34,12 @@ Watch live while swapping cables until the link is USB3:
 |------|---------------------|---------------------|----------------|
 | USB3 (≥5000) | OK | OK | OK |
 | USB2 (480) | WILL FAIL | OK (reduced spec) | WARN |
-| USB1 (12) | WILL FAIL | WARN | WARN |
+| USB1 (12) | WILL FAIL | WILL FAIL | WARN |
 
 A `WILL FAIL` camera (e.g. Femto Bolt on USB2) aborts at driver init — fix the
-cable and restart the ROS stack.
+cable and restart the ROS stack. A known USB2-tolerant camera that has dropped
+*below* USB2 (e.g. 12 Mbps) is also `WILL FAIL`: it is degraded below its
+known-good link, which is a genuine cable fault, not a tolerable reduction.
 
 ## Exit codes
 

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -43,7 +43,9 @@ make_device() {
   fi
 }
 
-new_root() { mktemp -d; }
+base_tmp="$(mktemp -d)"
+trap 'status=$?; rm -rf "$base_tmp"; exit $status' EXIT
+new_root() { mktemp -d -p "$base_tmp"; }
 
 # --- Task 1 tests: argument parsing ---
 
@@ -203,8 +205,9 @@ assert_contains "root-port unknown report WARN" "$rep_rootwarn" "WARN"
 
 r10="$(new_root)"; make_device "$r10" "2-3.4" "2bc5" "066b" "480" yes
 watch_out="$(SYSFS_USB_ROOT="$r10" timeout 2 bash "$SCRIPT" --watch --interval 1 2>/dev/null || true)"
-assert_contains "watch renders report"  "$watch_out" "Femto Bolt"
-assert_contains "watch shows refresh"   "$watch_out" "Ctrl-C to exit"
+assert_contains "watch renders report"      "$watch_out" "Femto Bolt"
+assert_contains "watch shows refresh"       "$watch_out" "Ctrl-C to exit"
+assert_contains "watch honours --interval"  "$watch_out" "refresh 1s"
 
 # --- Final-review fix C: empty-parent rendering has no dangling "on " ---
 rfc_root="$(new_root)"; make_device "$rfc_root" "2-1" "2bc5" "066b" "480" yes
@@ -215,6 +218,34 @@ case "$rep_rootport" in
 esac
 assert_eq "no dangling 'on ' for root-port camera" "no" "$dangling"
 assert_contains "root-port still shows vidpid" "$rep_rootport" "2bc5:066b"
+
+# --- Fail-fast guards: a camera with a bad sysfs read must exit 3, not mis-verdict ---
+
+# Empty speed file (exists but unreadable content) -> exit 3
+r_emptyspeed="$(new_root)"; make_device "$r_emptyspeed" "2-3.4" "2bc5" "066b" "480" yes
+: > "${r_emptyspeed}/2-3.4/speed"
+SYSFS_USB_ROOT="$r_emptyspeed" bash "$SCRIPT" --quiet 2>/dev/null
+assert_eq "empty speed -> 3" 3 "$?"
+
+# Non-numeric speed (e.g. kernel 'unknown') must fail fast, not become a WARN verdict
+r_badspeed="$(new_root)"; make_device "$r_badspeed" "2-3.4" "2bc5" "066b" "480" yes
+echo "unknown" > "${r_badspeed}/2-3.4/speed"
+SYSFS_USB_ROOT="$r_badspeed" bash "$SCRIPT" --quiet 2>/dev/null
+assert_eq "non-numeric speed -> 3" 3 "$?"
+
+# Missing vid/pid would make a known camera mis-verdict as unknown -> exit 3 instead
+r_novid="$(new_root)"; make_device "$r_novid" "2-3.4" "2bc5" "066b" "480" yes
+rm -f "${r_novid}/2-3.4/idVendor"
+SYSFS_USB_ROOT="$r_novid" bash "$SCRIPT" --quiet 2>/dev/null
+assert_eq "missing idVendor -> 3" 3 "$?"
+
+# read_attr on an existing but unreadable file must exit 3 (skipped as root, where chmod 000 is ignored)
+if [ "$(id -u)" -ne 0 ]; then
+  r_locked="$(new_root)"; echo "5000" > "${r_locked}/locked"; chmod 000 "${r_locked}/locked"
+  ( source "$SCRIPT"; read_attr "${r_locked}/locked" ) 2>/dev/null
+  assert_eq "read_attr unreadable -> 3" 3 "$?"
+  chmod 644 "${r_locked}/locked"
+fi
 
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -133,5 +133,26 @@ assert_eq "missing root -> 3" 3 "$?"
 out_q="$(SYSFS_USB_ROOT="$r_ok" bash "$SCRIPT" --quiet)"
 assert_eq "quiet is silent" "" "$out_q"
 
+# --- Task 7 tests: human report ---
+
+r7_fail="$(new_root)"; make_device "$r7_fail" "2-3.4" "2bc5" "066b" "480" yes
+rep_fail="$(SYSFS_USB_ROOT="$r7_fail" bash "$SCRIPT" || true)"
+assert_contains "report shows model"     "$rep_fail" "Femto Bolt"
+assert_contains "report shows WILL FAIL" "$rep_fail" "WILL FAIL"
+assert_contains "report shows speed"     "$rep_fail" "480"
+assert_contains "remediation cable"      "$rep_fail" "known-good USB3 cable"
+assert_contains "remediation restart"    "$rep_fail" "restart"
+assert_contains "remediation hub note"   "$rep_fail" "USB 2.0 Hub"
+
+r7_ok="$(new_root)"; make_device "$r7_ok" "2-3.3" "2bc5" "0803" "5000" yes
+rep_ok="$(SYSFS_USB_ROOT="$r7_ok" bash "$SCRIPT" || true)"
+assert_contains "ok report"           "$rep_ok" "OK (USB3)"
+case "$rep_ok" in *"known-good USB3 cable"*) ok_has_rem=yes ;; *) ok_has_rem=no ;; esac
+assert_eq "no remediation when all ok" "no" "$ok_has_rem"
+
+r7_none="$(new_root)"; make_device "$r7_none" "1-4" "0bda" "5420" "480" no
+rep_none="$(SYSFS_USB_ROOT="$r7_none" bash "$SCRIPT" || true)"
+assert_contains "none message" "$rep_none" "No USB cameras"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -62,5 +62,16 @@ assert_eq "quiet+verbose exits 1" 1 "$?"
 bash "$SCRIPT" --interval 0 2>/dev/null;   assert_eq "interval 0 exits 1" 1 "$?"
 bash "$SCRIPT" --interval abc 2>/dev/null; assert_eq "interval abc exits 1" 1 "$?"
 
+# --- Task 2 tests: read_attr / parent_hub ---
+
+t2_root="$(new_root)"
+echo "5000" > "${t2_root}/speed_file"
+assert_eq "read_attr present" "5000" "$( source "$SCRIPT"; read_attr "${t2_root}/speed_file" )"
+assert_eq "read_attr absent"  ""     "$( source "$SCRIPT"; read_attr "${t2_root}/nope" )"
+
+assert_eq "parent_hub nested" "2-3"  "$( source "$SCRIPT"; parent_hub "2-3.4" )"
+assert_eq "parent_hub deep"   "2-3.4" "$( source "$SCRIPT"; parent_hub "2-3.4.1" )"
+assert_eq "parent_hub root"   ""      "$( source "$SCRIPT"; parent_hub "usb2" )"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -83,5 +83,11 @@ make_device "$t3_root" "1-4"   "0bda" "5420" "480"  no    # hub (09)
 ( source "$SCRIPT"; is_camera "${t3_root}/1-4" );   assert_eq "hub not a camera" 1 "$?"
 ( source "$SCRIPT"; is_camera "${t3_root}/2-9.9" ); assert_eq "absent not a camera" 1 "$?"
 
+# --- Task 4 tests: lookup_model ---
+
+assert_eq "femto known"  "Femto Bolt|REQUIRES_USB3" "$( source "$SCRIPT"; lookup_model 2bc5:066b )"
+assert_eq "gemini known" "Gemini 336|USB2_TOLERANT" "$( source "$SCRIPT"; lookup_model 2bc5:0803 )"
+assert_eq "unknown id"   ""                          "$( source "$SCRIPT"; lookup_model 1234:5678 )"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -182,5 +182,22 @@ assert_eq "strict tolerant usb2 -> 0" 0 "$?"
 SYSFS_USB_ROOT="$r9_unknown" bash "$SCRIPT" --quiet
 assert_eq "nonstrict unknown usb2 -> 0" 0 "$?"
 
+# --- Regression tests: empty fields (root-port parent) must survive parsing ---
+
+# A. Root-port Femto on USB2: name has no dot so parent is empty. The empty
+#    parent field must not collapse the row and drop the WILL_FAIL verdict.
+r_rootfail="$(new_root)"; make_device "$r_rootfail" "2-1" "2bc5" "066b" "480" yes
+SYSFS_USB_ROOT="$r_rootfail" bash "$SCRIPT" --quiet
+assert_eq "root-port femto usb2 -> 1" 1 "$?"
+
+# B. Same fixture, full report must still surface the WILL FAIL verdict.
+rep_rootfail="$(SYSFS_USB_ROOT="$r_rootfail" bash "$SCRIPT" || true)"
+assert_contains "root-port femto report WILL FAIL" "$rep_rootfail" "WILL FAIL"
+
+# C. Root-port unknown camera: verdict WARN must be parsed correctly.
+r_rootwarn="$(new_root)"; make_device "$r_rootwarn" "2-2" "1234" "5678" "480" yes
+rep_rootwarn="$(SYSFS_USB_ROOT="$r_rootwarn" bash "$SCRIPT" || true)"
+assert_contains "root-port unknown report WARN" "$rep_rootwarn" "WARN"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -199,5 +199,12 @@ r_rootwarn="$(new_root)"; make_device "$r_rootwarn" "2-2" "1234" "5678" "480" ye
 rep_rootwarn="$(SYSFS_USB_ROOT="$r_rootwarn" bash "$SCRIPT" || true)"
 assert_contains "root-port unknown report WARN" "$rep_rootwarn" "WARN"
 
+# --- Task 10 tests: --watch (single frame under timeout) ---
+
+r10="$(new_root)"; make_device "$r10" "2-3.4" "2bc5" "066b" "480" yes
+watch_out="$(SYSFS_USB_ROOT="$r10" timeout 2 bash "$SCRIPT" --watch --interval 1 2>/dev/null || true)"
+assert_contains "watch renders report"  "$watch_out" "Femto Bolt"
+assert_contains "watch shows refresh"   "$watch_out" "Ctrl-C to exit"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# SKIP_CHECK
+# SKIP_CHECK — keep this. check_bash.yml `source`s every bash file to syntax-check
+# it (skipping those marked SKIP_CHECK). This test file has no BASH_SOURCE guard,
+# so sourcing it would run the whole suite at lint time; CI runs it explicitly via
+# check_camera_healthcheck.yml instead.
 # Self-contained tests for bin/usb-camera-healthcheck.sh. No bats dependency.
 # Builds fake sysfs trees under a temp dir (SYSFS_USB_ROOT) — no real hardware.
 
@@ -100,7 +103,7 @@ assert_eq "usb2 requires"      "WILL_FAIL"  "$( source "$SCRIPT"; verdict_for 48
 assert_eq "usb2 tolerant"      "OK_REDUCED" "$( source "$SCRIPT"; verdict_for 480 USB2_TOLERANT )"
 assert_eq "usb2 unknown"       "WARN"       "$( source "$SCRIPT"; verdict_for 480 '' )"
 assert_eq "usb1 requires"      "WILL_FAIL"  "$( source "$SCRIPT"; verdict_for 12 REQUIRES_USB3 )"
-assert_eq "usb1 tolerant"      "WARN"       "$( source "$SCRIPT"; verdict_for 12 USB2_TOLERANT )"
+assert_eq "usb1 tolerant"      "WILL_FAIL"  "$( source "$SCRIPT"; verdict_for 12 USB2_TOLERANT )"
 assert_eq "usb1 unknown"       "WARN"       "$( source "$SCRIPT"; verdict_for 12 '' )"
 
 # --- Task 6 tests: scan + exit codes via --quiet ---
@@ -122,6 +125,24 @@ SYSFS_USB_ROOT="$r_red" bash "$SCRIPT" --quiet; assert_eq "gemini usb2 -> 0" 0 "
 # Unknown camera on USB2, default (not strict) -> exit 0
 r_warn="$(new_root)"; make_device "$r_warn" "2-3.2" "1234" "5678" "480" yes
 SYSFS_USB_ROOT="$r_warn" bash "$SCRIPT" --quiet; assert_eq "unknown usb2 default -> 0" 0 "$?"
+
+# Gemini (USB2-tolerant) dropped to USB1 (12 Mbps): below its known-good link -> WILL_FAIL -> exit 1
+r_tol_usb1="$(new_root)"; make_device "$r_tol_usb1" "2-3.3" "2bc5" "0803" "12" yes
+SYSFS_USB_ROOT="$r_tol_usb1" bash "$SCRIPT" --quiet;          assert_eq "gemini usb1 -> 1"        1 "$?"
+SYSFS_USB_ROOT="$r_tol_usb1" bash "$SCRIPT" --quiet --strict; assert_eq "gemini usb1 strict -> 1" 1 "$?"
+
+# Mixed fleet: a healthy USB3 camera must not mask a failed one (worst verdict wins)
+r_mixed="$(new_root)"
+make_device "$r_mixed" "2-3.4" "2bc5" "066b" "5000" yes   # Femto USB3 -> OK
+make_device "$r_mixed" "2-3.3" "2bc5" "066b" "480"  yes   # Femto USB2 -> WILL_FAIL
+SYSFS_USB_ROOT="$r_mixed" bash "$SCRIPT" --quiet; assert_eq "mixed ok+fail -> 1" 1 "$?"
+
+# Mixed fleet under --strict: a healthy USB3 camera must not mask a strict unknown-USB2 failure
+r_mixed_strict="$(new_root)"
+make_device "$r_mixed_strict" "2-3.4" "2bc5" "066b" "5000" yes   # Femto USB3 -> OK
+make_device "$r_mixed_strict" "2-3.2" "1234" "5678" "480"  yes   # unknown USB2 -> WARN
+SYSFS_USB_ROOT="$r_mixed_strict" bash "$SCRIPT" --quiet --strict; assert_eq "mixed ok+strict-unknown -> 1" 1 "$?"
+SYSFS_USB_ROOT="$r_mixed_strict" bash "$SCRIPT" --quiet;          assert_eq "mixed ok+unknown nonstrict -> 0" 0 "$?"
 
 # No cameras (only a hub) -> exit 2
 r_none="$(new_root)"; make_device "$r_none" "1-4" "0bda" "5420" "480" no
@@ -226,6 +247,13 @@ r_emptyspeed="$(new_root)"; make_device "$r_emptyspeed" "2-3.4" "2bc5" "066b" "4
 : > "${r_emptyspeed}/2-3.4/speed"
 SYSFS_USB_ROOT="$r_emptyspeed" bash "$SCRIPT" --quiet 2>/dev/null
 assert_eq "empty speed -> 3" 3 "$?"
+
+# Missing speed file entirely: a confirmed camera must not be silently dropped
+# (reported as "no cameras") just because its speed attribute is absent -> exit 3
+r_nospeed="$(new_root)"; make_device "$r_nospeed" "2-3.4" "2bc5" "066b" "480" yes
+rm -f "${r_nospeed}/2-3.4/speed"
+SYSFS_USB_ROOT="$r_nospeed" bash "$SCRIPT" --quiet 2>/dev/null
+assert_eq "missing speed file -> 3" 3 "$?"
 
 # Non-numeric speed (e.g. kernel 'unknown') must fail fast, not become a WARN verdict
 r_badspeed="$(new_root)"; make_device "$r_badspeed" "2-3.4" "2bc5" "066b" "480" yes

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SKIP_CHECK
+# Self-contained tests for bin/usb-camera-healthcheck.sh. No bats dependency.
+# Builds fake sysfs trees under a temp dir (SYSFS_USB_ROOT) — no real hardware.
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${here}/../bin/usb-camera-healthcheck.sh"
+
+fail_count=0
+pass_count=0
+
+assert_eq() { # name expected actual
+  if [ "$2" = "$3" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    fail_count=$((fail_count + 1))
+    printf 'FAIL: %s\n  expected: [%s]\n  actual:   [%s]\n' "$1" "$2" "$3" >&2
+  fi
+}
+
+assert_contains() { # name haystack needle
+  case "$2" in
+    *"$3"*) pass_count=$((pass_count + 1)) ;;
+    *) fail_count=$((fail_count + 1))
+       printf 'FAIL: %s\n  expected to contain: [%s]\n  in: [%s]\n' "$1" "$3" "$2" >&2 ;;
+  esac
+}
+
+# make_device ROOT NAME VID PID SPEED CAMERA(yes|no)
+make_device() {
+  local root="$1" name="$2" vid="$3" pid="$4" speed="$5" cam="$6"
+  local d="${root}/${name}"
+  mkdir -p "${d}/${name}:1.0"
+  echo "$vid"   > "${d}/idVendor"
+  echo "$pid"   > "${d}/idProduct"
+  echo "$speed" > "${d}/speed"
+  echo "Fake ${vid}:${pid}" > "${d}/product"
+  echo "ef"     > "${d}/bDeviceClass"
+  if [ "$cam" = yes ]; then
+    echo "0e" > "${d}/${name}:1.0/bInterfaceClass"
+  else
+    echo "09" > "${d}/${name}:1.0/bInterfaceClass"
+  fi
+}
+
+new_root() { mktemp -d; }
+
+# --- Task 1 tests: argument parsing ---
+
+help_out="$(bash "$SCRIPT" --help)"; help_code=$?
+assert_eq "help exits 0" 0 "$help_code"
+assert_contains "help prints usage" "$help_out" "Usage:"
+
+bash "$SCRIPT" --bogus 2>/dev/null; assert_eq "unknown flag exits 1" 1 "$?"
+bash "$SCRIPT" -h >/dev/null;       assert_eq "short help exits 0" 0 "$?"
+
+bash "$SCRIPT" --quiet --watch 2>/dev/null
+assert_eq "quiet+watch exits 1" 1 "$?"
+bash "$SCRIPT" --quiet --verbose 2>/dev/null
+assert_eq "quiet+verbose exits 1" 1 "$?"
+
+bash "$SCRIPT" --interval 0 2>/dev/null;   assert_eq "interval 0 exits 1" 1 "$?"
+bash "$SCRIPT" --interval abc 2>/dev/null; assert_eq "interval abc exits 1" 1 "$?"
+
+printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
+[ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -206,5 +206,15 @@ watch_out="$(SYSFS_USB_ROOT="$r10" timeout 2 bash "$SCRIPT" --watch --interval 1
 assert_contains "watch renders report"  "$watch_out" "Femto Bolt"
 assert_contains "watch shows refresh"   "$watch_out" "Ctrl-C to exit"
 
+# --- Final-review fix C: empty-parent rendering has no dangling "on " ---
+rfc_root="$(new_root)"; make_device "$rfc_root" "2-1" "2bc5" "066b" "480" yes
+rep_rootport="$(SYSFS_USB_ROOT="$rfc_root" bash "$SCRIPT" || true)"
+case "$rep_rootport" in
+  *"on ]"*) dangling=yes ;;
+  *) dangling=no ;;
+esac
+assert_eq "no dangling 'on ' for root-port camera" "no" "$dangling"
+assert_contains "root-port still shows vidpid" "$rep_rootport" "2bc5:066b"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -73,5 +73,15 @@ assert_eq "parent_hub nested" "2-3"  "$( source "$SCRIPT"; parent_hub "2-3.4" )"
 assert_eq "parent_hub deep"   "2-3.4" "$( source "$SCRIPT"; parent_hub "2-3.4.1" )"
 assert_eq "parent_hub root"   ""      "$( source "$SCRIPT"; parent_hub "usb2" )"
 
+# --- Task 3 tests: is_camera ---
+
+t3_root="$(new_root)"
+make_device "$t3_root" "2-3.4" "2bc5" "066b" "480"  yes   # camera (0e)
+make_device "$t3_root" "1-4"   "0bda" "5420" "480"  no    # hub (09)
+
+( source "$SCRIPT"; is_camera "${t3_root}/2-3.4" ); assert_eq "camera detected" 0 "$?"
+( source "$SCRIPT"; is_camera "${t3_root}/1-4" );   assert_eq "hub not a camera" 1 "$?"
+( source "$SCRIPT"; is_camera "${t3_root}/2-9.9" ); assert_eq "absent not a camera" 1 "$?"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -154,5 +154,18 @@ r7_none="$(new_root)"; make_device "$r7_none" "1-4" "0bda" "5420" "480" no
 rep_none="$(SYSFS_USB_ROOT="$r7_none" bash "$SCRIPT" || true)"
 assert_contains "none message" "$rep_none" "No USB cameras"
 
+# --- Task 8 tests: --verbose tree ---
+
+r8="$(new_root)"
+make_device "$r8" "2-3.3" "2bc5" "0803" "5000" yes
+make_device "$r8" "1-4"   "0bda" "5420" "480"  no
+rep_plain="$(SYSFS_USB_ROOT="$r8" bash "$SCRIPT" || true)"
+case "$rep_plain" in *"Full USB device tree"*) plain_tree=yes ;; *) plain_tree=no ;; esac
+assert_eq "no tree without --verbose" "no" "$plain_tree"
+
+rep_v="$(SYSFS_USB_ROOT="$r8" bash "$SCRIPT" --verbose || true)"
+assert_contains "verbose tree header" "$rep_v" "Full USB device tree"
+assert_contains "verbose lists hub"   "$rep_v" "0bda:5420"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -101,5 +101,37 @@ assert_eq "usb1 requires"      "WILL_FAIL"  "$( source "$SCRIPT"; verdict_for 12
 assert_eq "usb1 tolerant"      "WARN"       "$( source "$SCRIPT"; verdict_for 12 USB2_TOLERANT )"
 assert_eq "usb1 unknown"       "WARN"       "$( source "$SCRIPT"; verdict_for 12 '' )"
 
+# --- Task 6 tests: scan + exit codes via --quiet ---
+
+# Femto on USB2 -> WILL_FAIL -> exit 1
+r_fail="$(new_root)"; make_device "$r_fail" "2-3.4" "2bc5" "066b" "480" yes
+SYSFS_USB_ROOT="$r_fail" bash "$SCRIPT" --quiet; assert_eq "femto usb2 -> 1" 1 "$?"
+
+# Femto + Gemini both USB3 -> exit 0
+r_ok="$(new_root)"
+make_device "$r_ok" "2-3.4" "2bc5" "066b" "5000" yes
+make_device "$r_ok" "2-3.3" "2bc5" "0803" "5000" yes
+SYSFS_USB_ROOT="$r_ok" bash "$SCRIPT" --quiet; assert_eq "both usb3 -> 0" 0 "$?"
+
+# Gemini on USB2 (tolerant) -> exit 0
+r_red="$(new_root)"; make_device "$r_red" "2-3.3" "2bc5" "0803" "480" yes
+SYSFS_USB_ROOT="$r_red" bash "$SCRIPT" --quiet; assert_eq "gemini usb2 -> 0" 0 "$?"
+
+# Unknown camera on USB2, default (not strict) -> exit 0
+r_warn="$(new_root)"; make_device "$r_warn" "2-3.2" "1234" "5678" "480" yes
+SYSFS_USB_ROOT="$r_warn" bash "$SCRIPT" --quiet; assert_eq "unknown usb2 default -> 0" 0 "$?"
+
+# No cameras (only a hub) -> exit 2
+r_none="$(new_root)"; make_device "$r_none" "1-4" "0bda" "5420" "480" no
+SYSFS_USB_ROOT="$r_none" bash "$SCRIPT" --quiet; assert_eq "no cameras -> 2" 2 "$?"
+
+# Missing sysfs root -> exit 3
+SYSFS_USB_ROOT="/nonexistent/usb/root" bash "$SCRIPT" --quiet 2>/dev/null
+assert_eq "missing root -> 3" 3 "$?"
+
+# --quiet produces no stdout
+out_q="$(SYSFS_USB_ROOT="$r_ok" bash "$SCRIPT" --quiet)"
+assert_eq "quiet is silent" "" "$out_q"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -89,5 +89,17 @@ assert_eq "femto known"  "Femto Bolt|REQUIRES_USB3" "$( source "$SCRIPT"; lookup
 assert_eq "gemini known" "Gemini 336|USB2_TOLERANT" "$( source "$SCRIPT"; lookup_model 2bc5:0803 )"
 assert_eq "unknown id"   ""                          "$( source "$SCRIPT"; lookup_model 1234:5678 )"
 
+# --- Task 5 tests: verdict_for (the full matrix from the spec) ---
+
+assert_eq "usb3 requires"      "OK"         "$( source "$SCRIPT"; verdict_for 5000 REQUIRES_USB3 )"
+assert_eq "usb3 tolerant"      "OK"         "$( source "$SCRIPT"; verdict_for 10000 USB2_TOLERANT )"
+assert_eq "usb3 unknown"       "OK"         "$( source "$SCRIPT"; verdict_for 5000 '' )"
+assert_eq "usb2 requires"      "WILL_FAIL"  "$( source "$SCRIPT"; verdict_for 480 REQUIRES_USB3 )"
+assert_eq "usb2 tolerant"      "OK_REDUCED" "$( source "$SCRIPT"; verdict_for 480 USB2_TOLERANT )"
+assert_eq "usb2 unknown"       "WARN"       "$( source "$SCRIPT"; verdict_for 480 '' )"
+assert_eq "usb1 requires"      "WILL_FAIL"  "$( source "$SCRIPT"; verdict_for 12 REQUIRES_USB3 )"
+assert_eq "usb1 tolerant"      "WARN"       "$( source "$SCRIPT"; verdict_for 12 USB2_TOLERANT )"
+assert_eq "usb1 unknown"       "WARN"       "$( source "$SCRIPT"; verdict_for 12 '' )"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_usb_camera_healthcheck.sh
+++ b/tests/test_usb_camera_healthcheck.sh
@@ -167,5 +167,20 @@ rep_v="$(SYSFS_USB_ROOT="$r8" bash "$SCRIPT" --verbose || true)"
 assert_contains "verbose tree header" "$rep_v" "Full USB device tree"
 assert_contains "verbose lists hub"   "$rep_v" "0bda:5420"
 
+# --- Task 9 tests: --strict ---
+
+r9_unknown="$(new_root)"; make_device "$r9_unknown" "2-3.2" "1234" "5678" "480" yes
+SYSFS_USB_ROOT="$r9_unknown" bash "$SCRIPT" --quiet --strict
+assert_eq "strict unknown usb2 -> 1" 1 "$?"
+
+# strict must NOT fail a known USB2-tolerant camera (we know it is fine)
+r9_tol="$(new_root)"; make_device "$r9_tol" "2-3.3" "2bc5" "0803" "480" yes
+SYSFS_USB_ROOT="$r9_tol" bash "$SCRIPT" --quiet --strict
+assert_eq "strict tolerant usb2 -> 0" 0 "$?"
+
+# without strict, unknown usb2 stays 0
+SYSFS_USB_ROOT="$r9_unknown" bash "$SCRIPT" --quiet
+assert_eq "nonstrict unknown usb2 -> 0" 0 "$?"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]


### PR DESCRIPTION
Add a tool/util to check that cameras are working with the right speeds/cables

plus, helper_bash_functions helper `er_usb_camera_healthcheck` to run this remotely

## Setup
First, if you're not in an er container (NOTE - THIS WILL ONLY WORK ONCE THIS IS MERGED)
```
echo 'er_usb_camera_healthcheck() {
    bash <(curl -Ls https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/main/bin/usb-camera-healthcheck.sh) "$@"
}' >> ~/.bashrc && source ~/.bashrc
```

or, if you want to TEST THIS BEFORE WE MERGE IT:
```
echo 'er_usb_camera_healthcheck() {
    bash <(curl -Ls https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/usb-camera-healthcheck/bin/usb-camera-healthcheck.sh) "$@"
}' >> ~/.bashrc && source ~/.bashrc
```
(If you're in an er container this will already be built in, or if it's an older er_container just run
```
update_helper_bash_functions
```

## Usage
```
er_usb_camera_healthcheck -h
```
