### PR TITLE
feat: er_update_source_repos — QA util to pull latest source in the er_robot container and rebuild

### DIFF
--- a/.github/workflows/check_update_source_repos.yml
+++ b/.github/workflows/check_update_source_repos.yml
@@ -1,0 +1,22 @@
+name: Check update source repos
+
+on: [push]
+
+jobs:
+  check_update_source_repos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v4
+
+      - name: shellcheck update-source-repos wrapper
+        shell: bash
+        run: shellcheck bin/update-source-repos.sh
+
+      - name: python syntax check payload
+        shell: bash
+        run: python3 -m py_compile bin/update_source_repos.py
+
+      - name: run update-source-repos tests
+        shell: bash
+        run: bash tests/test_update_source_repos.sh

--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -241,7 +241,8 @@ _fetch_and_call_remote_script() {
 
 er_usb_camera_healthcheck() { _fetch_and_call_remote_script "bin/usb-camera-healthcheck.sh" "$@"; }
 er_jetson_flash_preflight() { _fetch_and_call_remote_script "bin/jetson-flash-preflight.sh" "$@"; }
-er_update_source_repos() { _fetch_and_call_remote_script "bin/update-source-repos.sh" "$@"; }
+# PAT converted to env before any process spawns, so it never appears in argv/ps.
+er_update_source_repos() { GITHUB_PAT="${1:-${GITHUB_PAT:-}}" _fetch_and_call_remote_script "bin/update-source-repos.sh"; }
 
 # python linters
 LINTER_VERSIONS_URL="https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/${THIS_SCRIPT_BRANCH}/linter_versions.env"

--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -241,6 +241,7 @@ _fetch_and_call_remote_script() {
 
 er_usb_camera_healthcheck() { _fetch_and_call_remote_script "bin/usb-camera-healthcheck.sh" "$@"; }
 er_jetson_flash_preflight() { _fetch_and_call_remote_script "bin/jetson-flash-preflight.sh" "$@"; }
+er_update_source_repos() { _fetch_and_call_remote_script "bin/update-source-repos.sh" "$@"; }
 
 # python linters
 LINTER_VERSIONS_URL="https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/${THIS_SCRIPT_BRANCH}/linter_versions.env"

--- a/bin/update-source-repos.sh
+++ b/bin/update-source-repos.sh
@@ -11,7 +11,7 @@
 #
 # Env overrides: PAYLOAD (local payload path — skips the raw.githubusercontent
 #                fetch; used by tests/dev), ER_BUILD_TOOLS_BRANCH, NO_COLOR
-# Exit codes: 0 ok; 9 helpers/colcon_build missing in container; otherwise the
+# Exit codes: 0 ok; 97 helpers/colcon_build missing in container; otherwise the
 #             failing step's code.
 
 set -u
@@ -20,7 +20,15 @@ CONTAINER="er_robot"
 RAW_URL_BASE="https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/${ER_BUILD_TOOLS_BRANCH:-main}"
 PAYLOAD_REL_PATH="bin/update_source_repos.py"
 PAYLOAD_TMP=""
-trap 'rm -f "$PAYLOAD_TMP"' EXIT
+CONTAINER_TMP=""
+# shellcheck disable=SC2317  # invoked indirectly via the EXIT trap
+cleanup() {
+    rm -f "$PAYLOAD_TMP"
+    if [ -n "$CONTAINER_TMP" ]; then
+        docker exec "$CONTAINER" rm -f "$CONTAINER_TMP" >/dev/null 2>&1
+    fi
+}
+trap cleanup EXIT
 
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
     C_GRN=$'\033[32m'; C_YLW=$'\033[33m'; C_RED=$'\033[31m'; C_OFF=$'\033[0m'
@@ -54,8 +62,10 @@ fi
 
 # ---------- PAT live check: fail fast on a revoked/typo'd token ----------
 # The token reaches curl via a config file on stdin, never argv (invisible to ps).
-http_code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -K - \
-             https://api.github.com/user <<< "header = \"Authorization: token ${pat}\"")" \
+# printf is a builtin, so the token also never transits a herestring temp file.
+http_code="$(printf 'header = "Authorization: token %s"\n' "$pat" \
+             | curl -s -o /dev/null -w '%{http_code}' --max-time 10 -K - \
+                    https://api.github.com/user)" \
     || http_code="000"
 case "$http_code" in
     2??) ok "GitHub PAT verified" ;;
@@ -95,13 +105,13 @@ if ! docker cp "$payload_src" "${CONTAINER}:${dest}"; then
     err "failed to copy the update script into '${CONTAINER}'"
     exit 1
 fi
+CONTAINER_TMP="$dest"    # from here the EXIT trap removes it, even on Ctrl-C
 tty_flags=(-i)
 [ -t 0 ] && [ -t 1 ] && tty_flags=(-i -t)    # the branch picker needs a TTY when we have one
 # -e GITHUB_PAT with no value forwards it from this process's env — the token
 # never appears in argv on the host or in the container.
 GITHUB_PAT="$pat" docker exec "${tty_flags[@]}" -e GITHUB_PAT "$CONTAINER" python3 "$dest"
 payload_rc=$?
-docker exec "$CONTAINER" rm -f "$dest" >/dev/null 2>&1
 
 # ---------- build ----------
 case "$payload_rc" in
@@ -114,14 +124,14 @@ case "$payload_rc" in
         ok "Source updated — running colcon_build in '${CONTAINER}'..."
         # shellcheck disable=SC2016  # $HOME must expand inside the container, not here
         docker exec "${tty_flags[@]}" "$CONTAINER" bash -c '
-            [ -f "$HOME/.helper_bash_functions" ] || exit 9
+            [ -f "$HOME/.helper_bash_functions" ] || exit 97
             source "$HOME/.helper_bash_functions"
-            type colcon_build >/dev/null 2>&1 || exit 9
+            type colcon_build >/dev/null 2>&1 || exit 97
             colcon_build'
         build_rc=$?
-        if [ "$build_rc" -eq 9 ]; then
+        if [ "$build_rc" -eq 97 ]; then
             err "the .helper_bash_functions file (or colcon_build) is missing inside '${CONTAINER}' — cannot build"
-            exit 9
+            exit 97
         elif [ "$build_rc" -ne 0 ]; then
             err "colcon_build failed (exit ${build_rc})"
             exit "$build_rc"

--- a/bin/update-source-repos.sh
+++ b/bin/update-source-repos.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# update-source-repos.sh — pull latest source in the er_robot container, then rebuild
+# SKIP_CHECK — keep this. check_bash.yml source-executes unmarked bash files; this
+# script probes docker/network and must only run when invoked explicitly.
+#
+# Usage: update-source-repos.sh <github-pat>     (or set GITHUB_PAT in the env)
+#
+# Runs on the Jetson HOST. Injects bin/update_source_repos.py into the er_robot
+# container to fetch + fast-forward every repo under /cortex/.catkin_ws/src,
+# then runs colcon_build inside the container when anything updated.
+#
+# Env overrides: PAYLOAD (local payload path — skips the raw.githubusercontent
+#                fetch; used by tests/dev), ER_BUILD_TOOLS_BRANCH, NO_COLOR
+# Exit codes: 0 ok; 9 helpers/colcon_build missing in container; otherwise the
+#             failing step's code.
+
+set -u
+
+CONTAINER="er_robot"
+RAW_URL_BASE="https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/${ER_BUILD_TOOLS_BRANCH:-main}"
+PAYLOAD_REL_PATH="bin/update_source_repos.py"
+PAYLOAD_TMP=""
+trap 'rm -f "$PAYLOAD_TMP"' EXIT
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    C_GRN=$'\033[32m'; C_YLW=$'\033[33m'; C_RED=$'\033[31m'; C_OFF=$'\033[0m'
+else
+    C_GRN=""; C_YLW=""; C_RED=""; C_OFF=""
+fi
+err()  { echo "${C_RED}ERROR: $*${C_OFF}" >&2; }
+warn() { echo "${C_YLW}WARNING: $*${C_OFF}" >&2; }
+ok()   { echo "${C_GRN}$*${C_OFF}"; }
+
+usage() {
+    echo "Usage: er_update_source_repos <github-pat>"
+    echo "  (or set GITHUB_PAT in the environment)"
+    echo "  The PAT needs read access to the Extend-Robotics repos:"
+    echo "  classic (ghp_...) or fine-grained (github_pat_...)."
+}
+
+# ---------- PAT intake & validation ----------
+pat="${1:-${GITHUB_PAT:-}}"
+pat="${pat//[$'\t\r\n ']/}"    # strip all whitespace — PATs never contain any
+if [ -z "$pat" ]; then
+    err "no GitHub PAT supplied"
+    usage
+    exit 1
+fi
+if ! [[ "$pat" =~ ^ghp_[A-Za-z0-9]{36}$ || "$pat" =~ ^github_pat_[A-Za-z0-9_]{69,109}$ ]]; then
+    err "that does not look like a GitHub PAT (expected ghp_... 40 chars, or github_pat_...)"
+    usage
+    exit 1
+fi
+
+# ---------- PAT live check: fail fast on a revoked/typo'd token ----------
+# The token reaches curl via a config file on stdin, never argv (invisible to ps).
+http_code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -K - \
+             https://api.github.com/user <<< "header = \"Authorization: token ${pat}\"")" \
+    || http_code="000"
+case "$http_code" in
+    2??) ok "GitHub PAT verified" ;;
+    401) err "GitHub rejected the PAT (HTTP 401) — expired, revoked, or mistyped?"; exit 1 ;;
+    000) warn "could not reach api.github.com to verify the PAT — continuing anyway" ;;
+    *)   warn "unexpected HTTP ${http_code} from api.github.com — continuing anyway" ;;
+esac
+
+# ---------- container check ----------
+if ! command -v docker >/dev/null; then
+    err "docker is not installed / not on PATH"
+    exit 1
+fi
+running="$(docker container inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" || true
+if [ "$running" != "true" ]; then
+    err "container '${CONTAINER}' is not running — is the stack up on this Jetson?"
+    exit 1
+fi
+
+# ---------- obtain the payload ----------
+if [ -n "${PAYLOAD:-}" ] && [ -s "${PAYLOAD}" ]; then
+    payload_src="$PAYLOAD"
+else
+    PAYLOAD_TMP="$(mktemp "${TMPDIR:-/tmp}/er_update_source_repos.XXXXXXXXXX.py")"
+    # ?nocache= busts raw.githubusercontent's ~5-minute CDN cache, same pattern
+    # as _fetch_and_call_remote_script in .helper_bash_functions.
+    if ! curl -fsSL "${RAW_URL_BASE}/${PAYLOAD_REL_PATH}?nocache=$$-${RANDOM}" -o "$PAYLOAD_TMP"; then
+        err "failed to fetch ${PAYLOAD_REL_PATH} (branch ${ER_BUILD_TOOLS_BRANCH:-main})"
+        exit 1
+    fi
+    payload_src="$PAYLOAD_TMP"
+fi
+
+# ---------- run the payload inside the container ----------
+dest="/tmp/er_update_source_repos.$$.py"
+if ! docker cp "$payload_src" "${CONTAINER}:${dest}"; then
+    err "failed to copy the update script into '${CONTAINER}'"
+    exit 1
+fi
+tty_flags=(-i)
+[ -t 0 ] && [ -t 1 ] && tty_flags=(-i -t)    # the branch picker needs a TTY when we have one
+# -e GITHUB_PAT with no value forwards it from this process's env — the token
+# never appears in argv on the host or in the container.
+GITHUB_PAT="$pat" docker exec "${tty_flags[@]}" -e GITHUB_PAT "$CONTAINER" python3 "$dest"
+payload_rc=$?
+docker exec "$CONTAINER" rm -f "$dest" >/dev/null 2>&1
+
+# ---------- build ----------
+case "$payload_rc" in
+    10)
+        ok "Everything already up to date — skipping colcon_build."
+        exit 0
+        ;;
+    0)
+        echo ""
+        ok "Source updated — running colcon_build in '${CONTAINER}'..."
+        # shellcheck disable=SC2016  # $HOME must expand inside the container, not here
+        docker exec "${tty_flags[@]}" "$CONTAINER" bash -c '
+            [ -f "$HOME/.helper_bash_functions" ] || exit 9
+            source "$HOME/.helper_bash_functions"
+            type colcon_build >/dev/null 2>&1 || exit 9
+            colcon_build'
+        build_rc=$?
+        if [ "$build_rc" -eq 9 ]; then
+            err "the .helper_bash_functions file (or colcon_build) is missing inside '${CONTAINER}' — cannot build"
+            exit 9
+        elif [ "$build_rc" -ne 0 ]; then
+            err "colcon_build failed (exit ${build_rc})"
+            exit "$build_rc"
+        fi
+        ok "Build complete."
+        exit 0
+        ;;
+    *)
+        err "source update failed (exit ${payload_rc}) — skipping build"
+        exit "$payload_rc"
+        ;;
+esac

--- a/bin/update_source_repos.py
+++ b/bin/update_source_repos.py
@@ -60,8 +60,8 @@ def info(msg):
 
 def make_askpass():
     """Write a GIT_ASKPASS helper that answers from $GITHUB_PAT; return its path."""
-    fd, path = tempfile.mkstemp(prefix="er_askpass.", suffix=".sh")
-    with os.fdopen(fd, "w") as handle:
+    tmp_fd, path = tempfile.mkstemp(prefix="er_askpass.", suffix=".sh")
+    with os.fdopen(tmp_fd, "w") as handle:
         handle.write(ASKPASS_SCRIPT)
     os.chmod(path, stat.S_IRWXU)
     return path
@@ -206,7 +206,7 @@ def update_repo(path, name, askpass):
 
     res = git(path, ["merge", "--ff-only", "origin/{}".format(branch)], askpass)
     if res.returncode != 0:
-        return "skipped", "{} has diverged from origin/{} — not rewriting local commits".format(branch, branch)
+        return "skipped", "{b} has diverged from origin/{b} — not rewriting local commits".format(b=branch)
 
     if git(path, ["rev-parse", "--abbrev-ref", "@{u}"], askpass).returncode != 0:
         git(path, ["branch", "--set-upstream-to", "origin/{}".format(branch)], askpass)

--- a/bin/update_source_repos.py
+++ b/bin/update_source_repos.py
@@ -132,6 +132,7 @@ def pick_branch(repo_name, candidates):
         info("  {}) {}".format(idx, branch))
     info("  s) skip this repo")
     while True:
+        sys.stdout.flush()  # menu must be visible even when stdout is piped/block-buffered
         try:
             choice = input("Choose a branch to check out [1-{} or s]: ".format(len(candidates)))
         except EOFError:
@@ -180,13 +181,31 @@ def update_submodules(path, askpass):
     return None
 
 
-def update_repo(path, name, askpass):
-    """Fetch and fast-forward one repo. Returns (status, detail)."""
-    res = git(path, ["status", "--porcelain", "--untracked-files=no"], askpass)
+def preflight_problem(path, askpass):
+    """Return (status, detail) when the repo must not be updated, else None."""
+    # Submodule state is excluded from the dirty gate: a stale submodule pointer
+    # (e.g. a previous run that died between the superproject ff and the
+    # submodule update) must self-heal, not skip forever as "dirty".
+    res = git(path, ["status", "--porcelain", "--untracked-files=no", "--ignore-submodules=all"], askpass)
     if res.returncode != 0:
         return "failed", "git status failed: {}".format(res.stdout.strip())
     if res.stdout.strip():
         return "skipped", "uncommitted local changes — commit or stash them first"
+    if os.path.exists(os.path.join(path, ".gitmodules")):
+        res = git(path, ["submodule", "foreach", "--quiet", "--recursive",
+                         "git status --porcelain --untracked-files=no"], askpass)
+        if res.stdout.strip():
+            return "skipped", "uncommitted local changes inside a submodule — commit or stash them first"
+    if git(path, ["remote", "get-url", "origin"], askpass).returncode != 0:
+        return "skipped", "no 'origin' remote configured"
+    return None
+
+
+def update_repo(path, name, askpass):
+    """Fetch and fast-forward one repo. Returns (status, detail)."""
+    problem = preflight_problem(path, askpass)
+    if problem:
+        return problem
 
     res = git(path, ["fetch", "--prune", "origin"], askpass)
     if res.returncode != 0:
@@ -206,6 +225,8 @@ def update_repo(path, name, askpass):
 
     res = git(path, ["merge", "--ff-only", "origin/{}".format(branch)], askpass)
     if res.returncode != 0:
+        if "untracked working tree files" in res.stdout:
+            return "skipped", "an untracked file would be overwritten by the update — move it aside first"
         return "skipped", "{b} has diverged from origin/{b} — not rewriting local commits".format(b=branch)
 
     if git(path, ["rev-parse", "--abbrev-ref", "@{u}"], askpass).returncode != 0:

--- a/bin/update_source_repos.py
+++ b/bin/update_source_repos.py
@@ -92,9 +92,86 @@ def discover_repos(src_dir):
     return sorted(repos)
 
 
-def update_repo(path, name, askpass):  # pylint: disable=unused-argument
-    """Fetch and fast-forward one repo. Returns (status, detail). Real logic in Task 2."""
-    return "up-to-date", "not implemented yet"
+def current_branch(repo, askpass):
+    """Return the checked-out branch name, or None when HEAD is detached."""
+    res = git(repo, ["symbolic-ref", "--quiet", "--short", "HEAD"], askpass)
+    return res.stdout.strip() if res.returncode == 0 else None
+
+
+def short_rev(repo, ref, askpass):
+    """Return the abbreviated hash of ref, or None."""
+    res = git(repo, ["rev-parse", "--short", ref], askpass)
+    return res.stdout.strip() if res.returncode == 0 else None
+
+
+def ref_exists(repo, ref, askpass):
+    """True when the fully-qualified ref exists."""
+    return git(repo, ["show-ref", "--verify", "--quiet", ref], askpass).returncode == 0
+
+
+def resolve_detached(path, name, askpass):  # pylint: disable=unused-argument
+    """Pick the branch a detached HEAD belongs to. Real logic in Task 3."""
+    return None
+
+
+def checkout_branch(path, branch, askpass):
+    """Check out `branch`, creating a tracking branch when needed. Returns the git result."""
+    if ref_exists(path, "refs/heads/{}".format(branch), askpass):
+        return git(path, ["checkout", branch], askpass)
+    return git(path, ["checkout", "--track", "origin/{}".format(branch)], askpass)
+
+
+def update_submodules(path, askpass):
+    """Sync + init/update submodules to the superproject's recorded commits."""
+    if not os.path.exists(os.path.join(path, ".gitmodules")):
+        return None
+    for args in (["submodule", "sync", "--recursive"],
+                 ["submodule", "update", "--init", "--recursive"]):
+        res = git(path, args, askpass)
+        if res.returncode != 0:
+            return "submodule update failed: {}".format(res.stdout.strip())
+    return None
+
+
+def update_repo(path, name, askpass):
+    """Fetch and fast-forward one repo. Returns (status, detail)."""
+    res = git(path, ["status", "--porcelain", "--untracked-files=no"], askpass)
+    if res.returncode != 0:
+        return "failed", "git status failed: {}".format(res.stdout.strip())
+    if res.stdout.strip():
+        return "skipped", "uncommitted local changes — commit or stash them first"
+
+    res = git(path, ["fetch", "--prune", "origin"], askpass)
+    if res.returncode != 0:
+        return "failed", "fetch failed: {}".format(res.stdout.strip())
+
+    old = short_rev(path, "HEAD", askpass)
+    branch = current_branch(path, askpass)
+    if branch is None:
+        branch = resolve_detached(path, name, askpass)
+        if branch is None:
+            return "skipped", "detached HEAD left untouched"
+        res = checkout_branch(path, branch, askpass)
+        if res.returncode != 0:
+            return "failed", "checkout of {} failed: {}".format(branch, res.stdout.strip())
+    elif not ref_exists(path, "refs/remotes/origin/{}".format(branch), askpass):
+        return "skipped", "no origin/{} on the remote".format(branch)
+
+    res = git(path, ["merge", "--ff-only", "origin/{}".format(branch)], askpass)
+    if res.returncode != 0:
+        return "skipped", "{} has diverged from origin/{} — not rewriting local commits".format(branch, branch)
+
+    if git(path, ["rev-parse", "--abbrev-ref", "@{u}"], askpass).returncode != 0:
+        git(path, ["branch", "--set-upstream-to", "origin/{}".format(branch)], askpass)
+
+    sub_error = update_submodules(path, askpass)
+    if sub_error:
+        return "failed", sub_error
+
+    new = short_rev(path, "HEAD", askpass)
+    if new != old:
+        return "updated", "{} -> {} ({})".format(old, new, branch)
+    return "up-to-date", "{} ({})".format(new, branch)
 
 
 STATUS_PRINTER = {"updated": good, "up-to-date": info, "skipped": warn, "failed": error}

--- a/bin/update_source_repos.py
+++ b/bin/update_source_repos.py
@@ -109,9 +109,56 @@ def ref_exists(repo, ref, askpass):
     return git(repo, ["show-ref", "--verify", "--quiet", ref], askpass).returncode == 0
 
 
-def resolve_detached(path, name, askpass):  # pylint: disable=unused-argument
-    """Pick the branch a detached HEAD belongs to. Real logic in Task 3."""
-    return None
+def remote_branches(repo, askpass, extra_args):
+    """List origin branch names (without the origin/ prefix) matching extra_args filters."""
+    args = ["for-each-ref", "refs/remotes/origin", "--format=%(refname:short)"] + extra_args
+    res = git(repo, args, askpass)
+    if res.returncode != 0:
+        return []
+    names = []
+    for line in res.stdout.splitlines():
+        name = line.strip()
+        if not name or name.endswith("/HEAD") or not name.startswith("origin/"):
+            continue
+        names.append(name[len("origin/"):])
+    return names
+
+
+def pick_branch(repo_name, candidates):
+    """Interactively ask the QA tester which branch to check out; None means skip."""
+    warn("{}: can't tell which branch this detached HEAD belongs to.".format(repo_name))
+    info("  The commit is on these remote branches:")
+    for idx, branch in enumerate(candidates, 1):
+        info("  {}) {}".format(idx, branch))
+    info("  s) skip this repo")
+    while True:
+        try:
+            choice = input("Choose a branch to check out [1-{} or s]: ".format(len(candidates)))
+        except EOFError:
+            warn("no answer — skipping this repo")
+            return None
+        choice = choice.strip().lower()
+        if choice == "s":
+            return None
+        if choice.isdigit() and 1 <= int(choice) <= len(candidates):
+            return candidates[int(choice) - 1]
+        info("Invalid choice.")
+
+
+def resolve_detached(path, name, askpass):
+    """Work out which branch a detached HEAD belongs to; None when it stays detached."""
+    tips = remote_branches(path, askpass, ["--points-at", "HEAD"])
+    if len(tips) == 1:
+        info("  detached HEAD is the tip of origin/{} — checking it out".format(tips[0]))
+        return tips[0]
+    candidates = tips or remote_branches(path, askpass, ["--contains", "HEAD"])
+    if not candidates:
+        warn("  detached HEAD commit is not on any remote branch — leaving untouched")
+        return None
+    if len(candidates) == 1:
+        info("  detached HEAD commit is only on origin/{} — checking it out".format(candidates[0]))
+        return candidates[0]
+    return pick_branch(name, candidates)
 
 
 def checkout_branch(path, branch, askpass):

--- a/bin/update_source_repos.py
+++ b/bin/update_source_repos.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Container-side payload for er_update_source_repos.
+
+Updates every git repo under <workspace>/src: fetches, resolves detached
+HEADs to a branch (interactively when ambiguous), fast-forwards, and updates
+submodules. Never touches dirty or diverged repos.
+
+Auth: a GIT_ASKPASS helper feeds the PAT from $GITHUB_PAT so the token never
+appears in argv, remote URLs, or git config.
+
+Exit codes: 0 = at least one repo updated, 10 = success but nothing updated,
+1 = hard failure.
+"""
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+
+WORKSPACE = os.environ.get("ER_CATKIN_WS", "/cortex/.catkin_ws")
+
+USE_COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
+RED = "\033[0;31m" if USE_COLOR else ""
+GREEN = "\033[0;32m" if USE_COLOR else ""
+YELLOW = "\033[0;33m" if USE_COLOR else ""
+OFF = "\033[0m" if USE_COLOR else ""
+
+EXIT_UPDATED = 0
+EXIT_NOTHING_TO_DO = 10
+EXIT_FAILURE = 1
+
+ASKPASS_SCRIPT = """#!/bin/sh
+case "$1" in
+    [Uu]sername*) echo x-access-token ;;
+    *) echo "${GITHUB_PAT:-}" ;;
+esac
+"""
+
+
+def error(msg):
+    """Print a red error line."""
+    print("{}ERROR: {}{}".format(RED, msg, OFF))
+
+
+def warn(msg):
+    """Print a yellow warning line."""
+    print("{}WARNING: {}{}".format(YELLOW, msg, OFF))
+
+
+def good(msg):
+    """Print a green line."""
+    print("{}{}{}".format(GREEN, msg, OFF))
+
+
+def info(msg):
+    """Print a plain line."""
+    print(msg)
+
+
+def make_askpass():
+    """Write a GIT_ASKPASS helper that answers from $GITHUB_PAT; return its path."""
+    fd, path = tempfile.mkstemp(prefix="er_askpass.", suffix=".sh")
+    with os.fdopen(fd, "w") as handle:
+        handle.write(ASKPASS_SCRIPT)
+    os.chmod(path, stat.S_IRWXU)
+    return path
+
+
+def git(repo, args, askpass):
+    """Run git in `repo` with prompts disabled; return the CompletedProcess."""
+    env = dict(os.environ, GIT_ASKPASS=askpass, GIT_TERMINAL_PROMPT="0")
+    return subprocess.run(
+        ["git", "-C", repo] + args,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        check=False,
+    )
+
+
+def discover_repos(src_dir):
+    """Return sorted paths of git repos under src_dir, without descending into them."""
+    repos = []
+    for root, dirs, _ in os.walk(src_dir):
+        if ".git" in dirs or os.path.isfile(os.path.join(root, ".git")):
+            repos.append(root)
+            dirs[:] = []  # a repo manages its own subtree (incl. submodules)
+            continue
+        dirs.sort()
+    return sorted(repos)
+
+
+def update_repo(path, name, askpass):  # pylint: disable=unused-argument
+    """Fetch and fast-forward one repo. Returns (status, detail). Real logic in Task 2."""
+    return "up-to-date", "not implemented yet"
+
+
+STATUS_PRINTER = {"updated": good, "up-to-date": info, "skipped": warn, "failed": error}
+
+
+def print_summary(results):
+    """Print the end-of-run summary table."""
+    print("\n" + "=" * 60)
+    print("Summary:")
+    for name, status, detail in results:
+        STATUS_PRINTER[status]("  {:<11} {}  ({})".format(status, name, detail))
+
+
+def main():
+    """Entry point. Returns the process exit code."""
+    src = os.path.join(WORKSPACE, "src")
+    install = os.path.join(WORKSPACE, "install")
+    if not os.path.isdir(src):
+        if os.path.isdir(install):
+            error("this is not a source code container, the util will not work here")
+        else:
+            error("unexpected workspace layout: neither src/ nor install/ found under {}".format(WORKSPACE))
+        return EXIT_FAILURE
+
+    repos = discover_repos(src)
+    if not repos:
+        warn("no git repositories found under {}".format(src))
+        return EXIT_NOTHING_TO_DO
+
+    if not os.environ.get("GITHUB_PAT"):
+        warn("GITHUB_PAT is not set; private repos will fail to fetch")
+
+    askpass = make_askpass()
+    results = []
+    try:
+        for path in repos:
+            name = os.path.relpath(path, src)
+            info("\n=== {} ===".format(name))
+            status, detail = update_repo(path, name, askpass)
+            STATUS_PRINTER[status]("  {}: {}".format(status, detail))
+            results.append((name, status, detail))
+    finally:
+        os.unlink(askpass)
+
+    print_summary(results)
+    if any(status == "failed" for _, status, _ in results):
+        return EXIT_FAILURE
+    if any(status == "updated" for _, status, _ in results):
+        return EXIT_UPDATED
+    return EXIT_NOTHING_TO_DO
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/update-source-repos.md
+++ b/docs/update-source-repos.md
@@ -20,9 +20,10 @@ or with the token in the environment:
 The PAT needs read access to the Extend-Robotics repos — classic (`ghp_...`,
 `repo` scope) or fine-grained (`github_pat_...`, Contents: read). The token is
 verified against the GitHub API before anything runs, travels only via the
-environment (never argv, remote URLs, or git config), and is discarded when
-the util exits. Public third-party repos in `src/` work too — they never
-trigger the credential path.
+environment (never argv/`ps`, remote URLs, or git config), and is discarded
+when the util exits. Prefer the `GITHUB_PAT` env-var form if you don't want
+the token in your shell history. Public third-party repos in `src/` work too —
+they never trigger the credential path.
 
 ## What it does per repo
 
@@ -30,17 +31,22 @@ trigger the credential path.
 |------------|--------|
 | On a branch, behind origin | fast-forward to origin |
 | Already up to date | nothing |
-| Uncommitted tracked changes | **skipped** with a warning — local edits are never touched |
+| Uncommitted tracked changes (repo or submodule) | **skipped** with a warning — local edits are never touched |
 | Local commits diverged from origin | **skipped** with a warning — `--ff-only`, never rewrites |
+| Update would overwrite an untracked file | **skipped** with a warning — move the file aside first |
 | Branch missing on origin | **skipped** with a warning |
+| No `origin` remote | **skipped** with a warning |
 | Detached HEAD, tip of exactly one origin branch | that branch is checked out and pulled |
 | Detached HEAD, commit on exactly one branch | that branch is checked out and pulled |
 | Detached HEAD, commit on several branches | interactive picker (with a skip option) |
 | Detached HEAD, commit on no remote branch | **skipped** with a warning |
 | Has submodules | synced + updated to the superproject's recorded commits |
 
-Untracked files never block an update. A summary table at the end lists every
-repo as updated / up-to-date / skipped (with reason) / failed.
+Untracked files never block an update — unless the incoming update would
+overwrite one, in which case the repo is skipped with a warning. A stale
+submodule pointer left by an interrupted previous run self-heals on the next
+run. A summary table at the end lists every repo as updated / up-to-date /
+skipped (with reason) / failed.
 
 ## After updating
 
@@ -53,5 +59,5 @@ skipped.
 | Code | Meaning |
 |------|---------|
 | 0 | success — updated + built, or nothing to do |
-| 9 | `.helper_bash_functions` / `colcon_build` missing inside the container |
+| 97 | `.helper_bash_functions` / `colcon_build` missing inside the container |
 | other | the failing step's code (bad/rejected PAT, container down, pull or build failure) |

--- a/docs/update-source-repos.md
+++ b/docs/update-source-repos.md
@@ -1,0 +1,57 @@
+# update-source-repos
+
+Pulls the latest source code for every git repo in `/cortex/.catkin_ws/src`
+inside the running `er_robot` container, then rebuilds with `colcon_build`.
+For QA testing on Jetsons with a **source-code** image — stripped images (no
+`src/`, only `install/`) are rejected with a clear error.
+
+## Run it
+
+On the Jetson **host** (not inside the container), with the helper functions
+sourced:
+
+    er_update_source_repos <github-pat>
+
+or with the token in the environment:
+
+    export GITHUB_PAT=ghp_...
+    er_update_source_repos
+
+The PAT needs read access to the Extend-Robotics repos — classic (`ghp_...`,
+`repo` scope) or fine-grained (`github_pat_...`, Contents: read). The token is
+verified against the GitHub API before anything runs, travels only via the
+environment (never argv, remote URLs, or git config), and is discarded when
+the util exits. Public third-party repos in `src/` work too — they never
+trigger the credential path.
+
+## What it does per repo
+
+| Repo state | Action |
+|------------|--------|
+| On a branch, behind origin | fast-forward to origin |
+| Already up to date | nothing |
+| Uncommitted tracked changes | **skipped** with a warning — local edits are never touched |
+| Local commits diverged from origin | **skipped** with a warning — `--ff-only`, never rewrites |
+| Branch missing on origin | **skipped** with a warning |
+| Detached HEAD, tip of exactly one origin branch | that branch is checked out and pulled |
+| Detached HEAD, commit on exactly one branch | that branch is checked out and pulled |
+| Detached HEAD, commit on several branches | interactive picker (with a skip option) |
+| Detached HEAD, commit on no remote branch | **skipped** with a warning |
+| Has submodules | synced + updated to the superproject's recorded commits |
+
+Untracked files never block an update. A summary table at the end lists every
+repo as updated / up-to-date / skipped (with reason) / failed.
+
+## After updating
+
+If at least one repo updated, `colcon_build` (from `.helper_bash_functions`
+inside the container) runs automatically. If nothing updated, the build is
+skipped.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | success — updated + built, or nothing to do |
+| 9 | `.helper_bash_functions` / `colcon_build` missing inside the container |
+| other | the failing step's code (bad/rejected PAT, container down, pull or build failure) |

--- a/tests/test_update_source_repos.sh
+++ b/tests/test_update_source_repos.sh
@@ -237,6 +237,107 @@ run_payload
 assert_eq "detached orphan: exit 10" 10 "$rc"
 assert_contains "detached orphan: reason" "$out" "not on any remote branch"
 
+# (e) detached exactly at the tip of one branch -> auto-resolve without prompting
+new_workspace det_tip
+new_repo repo
+advance_remote repo main
+git -C "$src/repo" fetch -q origin
+git -C "$src/repo" checkout -q --detach origin/main
+git -C "$src/repo" branch -q -D main
+run_payload
+assert_eq "detached tip: exit 10 (already at tip)" 10 "$rc"
+assert_contains "detached tip: auto message" "$out" "tip of origin/main"
+tip_branch="$(git -C "$src/repo" symbolic-ref --short HEAD)"
+assert_eq "detached tip: on main" "main" "$tip_branch"
+
+# ---------- payload: submodule recovery & safety ----------
+# stale submodule pointer from an interrupted previous run must self-heal, not dirty-skip
+new_workspace subm_stale
+export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=protocol.file.allow GIT_CONFIG_VALUE_0=always
+new_repo sub
+new_repo super
+git -C "$src/super" submodule add -q "$remotes/sub.git" thesub
+git -C "$src/super" commit -qm add-submodule
+git -C "$src/super" push -q origin main
+advance_remote sub main
+rm -rf "$src/sub"   # the seeding clone would itself be discovered and updated
+tmpc="$(mktemp -d "$base_tmp/subadv.XXXXXX")"
+git clone -q "$remotes/super.git" "$tmpc/c" 2>/dev/null
+git -C "$tmpc/c" submodule update -q --init
+git -C "$tmpc/c/thesub" fetch -q origin
+git -C "$tmpc/c/thesub" checkout -q origin/main
+git -C "$tmpc/c" add thesub
+git -C "$tmpc/c" commit -qm bump-sub
+git -C "$tmpc/c" push -q origin main
+rm -rf "$tmpc"
+# simulate the interrupted run: superproject ff'd but submodule update never ran
+git -C "$src/super" fetch -q origin
+git -C "$src/super" merge -q --ff-only origin/main >/dev/null
+run_payload
+assert_eq "stale submodule: exit 10" 10 "$rc"
+assert_contains "stale submodule: not dirty-skipped" "$out" "up-to-date  super"
+sub_head2="$(git -C "$src/super/thesub" rev-parse HEAD)"
+recorded2="$(git -C "$src/super" ls-tree HEAD thesub | awk '{print $3}')"
+assert_eq "stale submodule: healed to recorded commit" "$recorded2" "$sub_head2"
+
+# genuinely dirty submodule content must skip, never be clobbered
+new_workspace subm_dirty
+new_repo sub2
+tmpc="$(mktemp -d "$base_tmp/subf.XXXXXX")"
+git clone -q "$remotes/sub2.git" "$tmpc/c" 2>/dev/null
+echo v1 > "$tmpc/c/f.txt"
+git -C "$tmpc/c" add f.txt
+git -C "$tmpc/c" commit -qm add-f
+git -C "$tmpc/c" push -q origin main
+rm -rf "$tmpc"
+git -C "$src/sub2" pull -q --ff-only origin main
+new_repo super2
+git -C "$src/super2" submodule add -q "$remotes/sub2.git" thesub
+git -C "$src/super2" commit -qm add-submodule
+git -C "$src/super2" push -q origin main
+advance_remote super2 main
+echo hacked > "$src/super2/thesub/f.txt"
+run_payload
+assert_eq "dirty submodule: exit 10" 10 "$rc"
+assert_contains "dirty submodule: skipped" "$out" "skipped     super2"
+assert_contains "dirty submodule: reason" "$out" "inside a submodule"
+dirty_sub_content="$(cat "$src/super2/thesub/f.txt")"
+assert_eq "dirty submodule: edit untouched" "hacked" "$dirty_sub_content"
+unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+
+# ---------- payload: untracked-file collision & missing origin ----------
+# upstream adds a file that exists untracked locally -> skip with a clear reason
+new_workspace clash
+new_repo repo
+tmpc="$(mktemp -d "$base_tmp/clash.XXXXXX")"
+git clone -q -b main "$remotes/repo.git" "$tmpc/c" 2>/dev/null
+echo upstream > "$tmpc/c/clash.txt"
+git -C "$tmpc/c" add clash.txt
+git -C "$tmpc/c" commit -qm add-clash
+git -C "$tmpc/c" push -q origin main
+rm -rf "$tmpc"
+echo local > "$src/repo/clash.txt"
+run_payload
+assert_eq "untracked collision: exit 10" 10 "$rc"
+assert_contains "untracked collision: skipped" "$out" "skipped     repo"
+assert_contains "untracked collision: reason" "$out" "untracked file"
+assert_not_contains "untracked collision: not called diverged" "$out" "diverged"
+clash_content="$(cat "$src/repo/clash.txt")"
+assert_eq "untracked collision: file untouched" "local" "$clash_content"
+
+# a repo with no origin remote is skipped, not a run-wide failure
+new_workspace noorigin
+new_repo good
+advance_remote good main
+mkdir "$src/local_only"
+git init -q -b main "$src/local_only"
+git -C "$src/local_only" commit -q --allow-empty -m c1
+run_payload
+assert_eq "no origin: exit 0 (good repo still updates)" 0 "$rc"
+assert_contains "no origin: skipped" "$out" "skipped     local_only"
+assert_contains "no origin: reason" "$out" "no 'origin' remote"
+assert_contains "no origin: other repo updated" "$out" "updated     good"
+
 # ---------- wrapper: shims ----------
 shims="$base_tmp/shims"
 mkdir -p "$shims"
@@ -263,6 +364,7 @@ EOF
 cat > "$shims/curl" <<'EOF'
 #!/bin/bash
 # API check has -w '%{http_code}' and its config on stdin; payload fetch has -o <file>.
+echo "curl $*" >> "${CURL_LOG:-/dev/null}"
 args="$*"
 out=""; prev=""
 for a in "$@"; do [ "$prev" = "-o" ] && [ "$a" != "/dev/null" ] && out="$a"; prev="$a"; done
@@ -277,7 +379,9 @@ chmod +x "$shims/docker" "$shims/curl"
 
 run_wrapper() { # args... ; uses env knobs; sets $out and $rc
   export DOCKER_LOG="$base_tmp/docker.log.$RANDOM"
+  export CURL_LOG="$base_tmp/curl.log.$RANDOM"
   : > "$DOCKER_LOG"
+  : > "$CURL_LOG"
   out="$(PATH="$shims:$PATH" PAYLOAD="${PAYLOAD_OVERRIDE:-$PAYLOAD}" NO_COLOR=1 \
          bash "$WRAPPER" "$@" 2>&1 < /dev/null)"
   rc=$?
@@ -326,6 +430,10 @@ PAYLOAD_OVERRIDE="/nonexistent" FAKE_FETCH_RC=22 run_wrapper "$good_pat"
 assert_eq "fetch fail: exit 1" 1 "$rc"
 assert_contains "fetch fail: message" "$out" "failed to fetch"
 
+FAKE_CP_RC=1 run_wrapper "$good_pat"
+assert_eq "docker cp fail: exit 1" 1 "$rc"
+assert_contains "docker cp fail: message" "$out" "failed to copy"
+
 # ---------- wrapper: payload rc -> build behaviour ----------
 run_wrapper "$good_pat"    # payload rc 0 -> build runs
 assert_eq "update ok: exit 0" 0 "$rc"
@@ -333,6 +441,8 @@ docker_log="$(cat "$DOCKER_LOG")"
 assert_contains "update ok: payload ran" "$docker_log" "python3"
 assert_contains "update ok: build ran" "$docker_log" "colcon_build"
 assert_not_contains "pat never in docker argv" "$docker_log" "$good_pat"
+curl_log="$(cat "$CURL_LOG")"
+assert_not_contains "pat never in curl argv" "$curl_log" "$good_pat"
 
 FAKE_PAYLOAD_RC=10 run_wrapper "$good_pat"
 assert_eq "nothing updated: exit 0" 0 "$rc"
@@ -345,8 +455,8 @@ assert_eq "payload failed: exit 1" 1 "$rc"
 docker_log="$(cat "$DOCKER_LOG")"
 assert_not_contains "payload failed: no build" "$docker_log" "colcon_build"
 
-FAKE_BUILD_RC=9 run_wrapper "$good_pat"
-assert_eq "helpers missing: exit 9" 9 "$rc"
+FAKE_BUILD_RC=97 run_wrapper "$good_pat"
+assert_eq "helpers missing: exit 97" 97 "$rc"
 assert_contains "helpers missing: message" "$out" "helper_bash_functions"
 
 FAKE_BUILD_RC=2 run_wrapper "$good_pat"

--- a/tests/test_update_source_repos.sh
+++ b/tests/test_update_source_repos.sh
@@ -111,5 +111,75 @@ run_payload
 assert_contains "discovery: finds top-level repo" "$out" "=== top ==="
 assert_contains "discovery: finds nested repo" "$out" "=== group/nested ==="
 
+# ---------- payload: on-branch behaviours ----------
+new_workspace onbranch
+new_repo behind          # will be behind origin -> updated
+new_repo current         # already up to date
+new_repo dirty           # local tracked modification -> skipped
+new_repo diverged        # local commit + remote commit -> skipped
+new_repo orphan          # branch with no matching remote branch -> skipped
+advance_remote behind main
+echo tracked > "$src/dirty/file.txt"
+git -C "$src/dirty" add file.txt
+git -C "$src/dirty" commit -qm add-file
+git -C "$src/dirty" push -q origin main
+echo changed > "$src/dirty/file.txt"   # unstaged tracked change
+git -C "$src/diverged" commit -q --allow-empty -m local-only
+advance_remote diverged main
+git -C "$src/orphan" checkout -q -b lonely_branch
+run_payload
+assert_eq "on-branch mix: exit 0 (something updated)" 0 "$rc"
+assert_contains "behind: updated" "$out" "updated     behind"
+assert_contains "current: up to date" "$out" "up-to-date  current"
+assert_contains "dirty: skipped" "$out" "skipped     dirty"
+assert_contains "dirty: reason" "$out" "uncommitted local changes"
+assert_contains "diverged: skipped" "$out" "skipped     diverged"
+assert_contains "diverged: reason" "$out" "diverged"
+assert_contains "orphan: skipped" "$out" "no origin/lonely_branch"
+old_dirty_content="$(cat "$src/dirty/file.txt")"
+assert_eq "dirty: file untouched" "changed" "$old_dirty_content"
+
+# untracked files must NOT block updates
+new_workspace untracked
+new_repo repo
+advance_remote repo main
+echo scratch > "$src/repo/scratch.log"
+run_payload
+assert_eq "untracked: exit 0" 0 "$rc"
+assert_contains "untracked: updated" "$out" "updated     repo"
+
+# all repos already current -> exit 10
+new_workspace nochange
+new_repo repo
+run_payload
+assert_eq "nothing to do: exit 10" 10 "$rc"
+
+# missing upstream config: branch exists on remote but no @{u} -> still ffs
+new_workspace noupstream
+new_repo repo
+advance_remote repo main
+git -C "$src/repo" branch -q --unset-upstream
+run_payload
+assert_eq "no upstream: exit 0" 0 "$rc"
+assert_contains "no upstream: updated" "$out" "updated     repo"
+
+# ---------- payload: submodules ----------
+new_workspace subm
+export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=protocol.file.allow GIT_CONFIG_VALUE_0=always
+new_repo sub
+new_repo super
+git -C "$src/super" submodule add -q "$remotes/sub.git" thesub
+git -C "$src/super" commit -qm add-submodule
+git -C "$src/super" push -q origin main
+git -C "$src/super" submodule deinit -f -q thesub   # simulate uninitialised submodule
+advance_remote super main
+run_payload
+assert_eq "submodule: exit 0" 0 "$rc"
+assert_contains "submodule: super updated" "$out" "updated     super"
+sub_head="$(git -C "$src/super/thesub" rev-parse HEAD 2>/dev/null)"
+recorded="$(git -C "$src/super" ls-tree HEAD thesub | awk '{print $3}')"
+assert_eq "submodule: checked out at recorded commit" "$recorded" "$sub_head"
+unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_update_source_repos.sh
+++ b/tests/test_update_source_repos.sh
@@ -181,5 +181,61 @@ recorded="$(git -C "$src/super" ls-tree HEAD thesub | awk '{print $3}')"
 assert_eq "submodule: checked out at recorded commit" "$recorded" "$sub_head"
 unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
 
+# ---------- payload: detached HEAD ----------
+# (a) exactly one branch contains the commit -> auto-resolve, checkout, pull
+new_workspace det_auto
+new_repo repo
+advance_remote repo main
+git -C "$src/repo" fetch -q origin
+git -C "$src/repo" checkout -q --detach HEAD   # detach at old commit; only main contains it
+git -C "$src/repo" branch -q -D main
+advance_remote repo main
+run_payload
+assert_eq "detached auto: exit 0" 0 "$rc"
+assert_contains "detached auto: updated" "$out" "updated     repo"
+resolved_branch="$(git -C "$src/repo" symbolic-ref --short HEAD)"
+assert_eq "detached auto: back on main" "main" "$resolved_branch"
+
+# (b) ambiguous: commit contained in two branches, tip of neither -> picker; pick 1 (alpha)
+new_workspace det_pick
+new_repo repo alpha
+git -C "$src/repo" push -q origin alpha:zeta   # second branch, same history
+git -C "$src/repo" fetch -q origin
+git -C "$src/repo" checkout -q --detach HEAD
+git -C "$src/repo" branch -q -D alpha
+advance_remote repo alpha                      # both branches move past the commit,
+advance_remote repo zeta                       # so --points-at finds no tips
+printf '1\n' > "$base_tmp/answer_pick"
+run_payload "$base_tmp/answer_pick"
+assert_eq "detached picker: exit 0" 0 "$rc"
+assert_contains "detached picker: offers alpha" "$out" "1) alpha"
+assert_contains "detached picker: offers zeta" "$out" "2) zeta"
+assert_contains "detached picker: skip option" "$out" "s) skip this repo"
+picked_branch="$(git -C "$src/repo" symbolic-ref --short HEAD)"
+assert_eq "detached picker: on alpha" "alpha" "$picked_branch"
+
+# (c) ambiguous (two branch tips at the commit), user chooses skip
+new_workspace det_skip
+new_repo repo alpha
+git -C "$src/repo" push -q origin alpha:zeta
+git -C "$src/repo" fetch -q origin
+git -C "$src/repo" checkout -q --detach HEAD
+git -C "$src/repo" branch -q -D alpha
+printf 's\n' > "$base_tmp/answer_skip"
+run_payload "$base_tmp/answer_skip"
+assert_eq "detached skip: exit 10" 10 "$rc"
+assert_contains "detached skip: reported" "$out" "skipped     repo"
+still_detached="$(git -C "$src/repo" symbolic-ref --short -q HEAD; echo "rc=$?")"
+assert_contains "detached skip: still detached" "$still_detached" "rc=1"
+
+# (d) commit on no remote branch -> warn + skip
+new_workspace det_orphan
+new_repo repo
+git -C "$src/repo" checkout -q --detach HEAD
+git -C "$src/repo" commit -q --allow-empty -m local-orphan
+run_payload
+assert_eq "detached orphan: exit 10" 10 "$rc"
+assert_contains "detached orphan: reason" "$out" "not on any remote branch"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]

--- a/tests/test_update_source_repos.sh
+++ b/tests/test_update_source_repos.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# SKIP_CHECK — keep this. check_bash.yml `source`s every bash file to syntax-check
+# it (skipping those marked SKIP_CHECK); sourcing this would run the suite.
+# Self-contained tests for bin/update-source-repos.sh + bin/update_source_repos.py.
+# No docker, no network: docker/curl are PATH shims; the payload is exercised
+# against real local git repos via the ER_CATKIN_WS override.
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${REPO:-${here}/..}"
+WRAPPER="${REPO}/bin/update-source-repos.sh"
+PAYLOAD="${REPO}/bin/update_source_repos.py"
+
+fail_count=0
+pass_count=0
+
+assert_eq() { # name expected actual
+  if [ "$2" = "$3" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    fail_count=$((fail_count + 1))
+    printf 'FAIL: %s\n  expected: [%s]\n  actual:   [%s]\n' "$1" "$2" "$3" >&2
+  fi
+}
+
+assert_contains() { # name haystack needle
+  case "$2" in
+    *"$3"*) pass_count=$((pass_count + 1)) ;;
+    *) fail_count=$((fail_count + 1))
+       printf 'FAIL: %s\n  expected to contain: [%s]\n  in: [%s]\n' "$1" "$3" "$2" >&2 ;;
+  esac
+}
+
+assert_not_contains() { # name haystack needle
+  case "$2" in
+    *"$3"*) fail_count=$((fail_count + 1))
+            printf 'FAIL: %s\n  expected NOT to contain: [%s]\n' "$1" "$3" >&2 ;;
+    *) pass_count=$((pass_count + 1)) ;;
+  esac
+}
+
+base_tmp="$(mktemp -d)"
+trap 'status=$?; rm -rf "$base_tmp"; exit $status' EXIT
+
+# Deterministic git identity/branches for all fixture repos
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test \
+       GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+export NO_COLOR=1
+
+# ---------- payload fixture helpers ----------
+# new_workspace <name> -> sets $ws, $src, $remotes
+new_workspace() {
+  ws="$base_tmp/$1"
+  src="$ws/src"
+  remotes="$base_tmp/$1-remotes"
+  mkdir -p "$src" "$remotes"
+}
+
+# new_repo <name> [branch] -> bare remote at $remotes/<name>.git, clone at $src/<name>
+new_repo() {
+  local name="$1" branch="${2:-main}"
+  git init -q --bare -b "$branch" "$remotes/$name.git"
+  git clone -q "$remotes/$name.git" "$src/$name" 2>/dev/null
+  git -C "$src/$name" commit -q --allow-empty -m c1
+  git -C "$src/$name" push -q origin "$branch"
+}
+
+# advance_remote <name> <branch> -> add a commit to the remote (via a throwaway clone)
+advance_remote() {
+  local name="$1" branch="$2" tmp
+  tmp="$(mktemp -d "$base_tmp/adv.XXXXXX")"
+  git clone -q -b "$branch" "$remotes/$name.git" "$tmp/c" 2>/dev/null
+  git -C "$tmp/c" commit -q --allow-empty -m "advance-$RANDOM"
+  git -C "$tmp/c" push -q origin "$branch"
+  rm -rf "$tmp"
+}
+
+run_payload() { # [stdin-file] ; uses $ws; sets $out and $rc
+  local stdin_src="${1:-/dev/null}"
+  out="$(ER_CATKIN_WS="$ws" python3 "$PAYLOAD" < "$stdin_src" 2>&1)"
+  rc=$?
+}
+
+# ---------- payload: workspace gate ----------
+new_workspace gate_stripped
+rm -rf "$src"
+mkdir -p "$ws/install"
+run_payload
+assert_eq "stripped image: exit 1" 1 "$rc"
+assert_contains "stripped image: message" "$out" "this is not a source code container, the util will not work here"
+
+new_workspace gate_weird
+rm -rf "$src"
+run_payload
+assert_eq "unexpected layout: exit 1" 1 "$rc"
+assert_contains "unexpected layout: message" "$out" "unexpected workspace layout"
+
+new_workspace gate_empty_src
+run_payload
+assert_eq "empty src: exit 10" 10 "$rc"
+assert_contains "empty src: message" "$out" "no git repositories found"
+
+# ---------- payload: discovery finds nested repos, doesn't descend into them ----------
+new_workspace disco
+new_repo top
+mkdir -p "$src/group"
+git init -q --bare -b main "$remotes/nested.git"
+git clone -q "$remotes/nested.git" "$src/group/nested" 2>/dev/null
+git -C "$src/group/nested" commit -q --allow-empty -m c1
+git -C "$src/group/nested" push -q origin main
+run_payload
+assert_contains "discovery: finds top-level repo" "$out" "=== top ==="
+assert_contains "discovery: finds nested repo" "$out" "=== group/nested ==="
+
+printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
+[ "$fail_count" -eq 0 ]

--- a/tests/test_update_source_repos.sh
+++ b/tests/test_update_source_repos.sh
@@ -237,5 +237,121 @@ run_payload
 assert_eq "detached orphan: exit 10" 10 "$rc"
 assert_contains "detached orphan: reason" "$out" "not on any remote branch"
 
+# ---------- wrapper: shims ----------
+shims="$base_tmp/shims"
+mkdir -p "$shims"
+
+cat > "$shims/docker" <<'EOF'
+#!/bin/bash
+echo "docker $*" >> "$DOCKER_LOG"
+case "$1" in
+  container)  # container inspect -f ... er_robot
+    if [ "${FAKE_CONTAINER_RUNNING:-true}" = "true" ]; then echo "true"; exit 0; fi
+    exit 1 ;;
+  cp) exit "${FAKE_CP_RC:-0}" ;;
+  exec)
+    case "$*" in
+      *python3*) exit "${FAKE_PAYLOAD_RC:-0}" ;;
+      *"rm -f"*) exit 0 ;;
+      *colcon_build*) exit "${FAKE_BUILD_RC:-0}" ;;
+      *) exit 0 ;;
+    esac ;;
+  *) exit 0 ;;
+esac
+EOF
+
+cat > "$shims/curl" <<'EOF'
+#!/bin/bash
+# API check has -w '%{http_code}' and its config on stdin; payload fetch has -o <file>.
+args="$*"
+out=""; prev=""
+for a in "$@"; do [ "$prev" = "-o" ] && [ "$a" != "/dev/null" ] && out="$a"; prev="$a"; done
+if [[ "$args" == *"%{http_code}"* ]]; then cat > /dev/null; printf '%s' "${FAKE_HTTP_CODE:-200}"; exit 0; fi
+if [ -n "$out" ]; then
+  [ "${FAKE_FETCH_RC:-0}" -ne 0 ] && exit "${FAKE_FETCH_RC}"
+  echo "print('fake payload')" > "$out"; exit 0
+fi
+exit 0
+EOF
+chmod +x "$shims/docker" "$shims/curl"
+
+run_wrapper() { # args... ; uses env knobs; sets $out and $rc
+  export DOCKER_LOG="$base_tmp/docker.log.$RANDOM"
+  : > "$DOCKER_LOG"
+  out="$(PATH="$shims:$PATH" PAYLOAD="${PAYLOAD_OVERRIDE:-$PAYLOAD}" NO_COLOR=1 \
+         bash "$WRAPPER" "$@" 2>&1 < /dev/null)"
+  rc=$?
+}
+
+good_pat="ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"   # ghp_ + 36 chars
+fg_pat="github_pat_$(printf 'a%.0s' $(seq 1 82))"      # fine-grained shape
+
+# ---------- wrapper: PAT validation ----------
+run_wrapper
+assert_eq "no pat: exit 1" 1 "$rc"
+assert_contains "no pat: usage" "$out" "Usage: er_update_source_repos"
+
+run_wrapper "notatoken"
+assert_eq "bad prefix: exit 1" 1 "$rc"
+assert_contains "bad prefix: message" "$out" "does not look like a GitHub PAT"
+
+run_wrapper "ghp_tooshort"
+assert_eq "bad length: exit 1" 1 "$rc"
+
+run_wrapper "  ${good_pat}
+"
+assert_eq "whitespace-wrapped pat accepted" 0 "$rc"
+
+run_wrapper "$fg_pat"
+assert_eq "fine-grained pat accepted" 0 "$rc"
+
+GITHUB_PAT="$good_pat" run_wrapper
+assert_eq "pat via env accepted" 0 "$rc"
+
+# ---------- wrapper: PAT live check ----------
+FAKE_HTTP_CODE=401 run_wrapper "$good_pat"
+assert_eq "401: exit 1" 1 "$rc"
+assert_contains "401: message" "$out" "rejected the PAT"
+
+FAKE_HTTP_CODE=000 run_wrapper "$good_pat"
+assert_eq "network down: continues" 0 "$rc"
+assert_contains "network down: warns" "$out" "could not reach api.github.com"
+
+# ---------- wrapper: container / fetch failures ----------
+FAKE_CONTAINER_RUNNING=false run_wrapper "$good_pat"
+assert_eq "container down: exit 1" 1 "$rc"
+assert_contains "container down: message" "$out" "er_robot"
+
+PAYLOAD_OVERRIDE="/nonexistent" FAKE_FETCH_RC=22 run_wrapper "$good_pat"
+assert_eq "fetch fail: exit 1" 1 "$rc"
+assert_contains "fetch fail: message" "$out" "failed to fetch"
+
+# ---------- wrapper: payload rc -> build behaviour ----------
+run_wrapper "$good_pat"    # payload rc 0 -> build runs
+assert_eq "update ok: exit 0" 0 "$rc"
+docker_log="$(cat "$DOCKER_LOG")"
+assert_contains "update ok: payload ran" "$docker_log" "python3"
+assert_contains "update ok: build ran" "$docker_log" "colcon_build"
+assert_not_contains "pat never in docker argv" "$docker_log" "$good_pat"
+
+FAKE_PAYLOAD_RC=10 run_wrapper "$good_pat"
+assert_eq "nothing updated: exit 0" 0 "$rc"
+assert_contains "nothing updated: message" "$out" "skipping colcon_build"
+docker_log="$(cat "$DOCKER_LOG")"
+assert_not_contains "nothing updated: no build" "$docker_log" "colcon_build"
+
+FAKE_PAYLOAD_RC=1 run_wrapper "$good_pat"
+assert_eq "payload failed: exit 1" 1 "$rc"
+docker_log="$(cat "$DOCKER_LOG")"
+assert_not_contains "payload failed: no build" "$docker_log" "colcon_build"
+
+FAKE_BUILD_RC=9 run_wrapper "$good_pat"
+assert_eq "helpers missing: exit 9" 9 "$rc"
+assert_contains "helpers missing: message" "$out" "helper_bash_functions"
+
+FAKE_BUILD_RC=2 run_wrapper "$good_pat"
+assert_eq "build failed: exit 2" 2 "$rc"
+assert_contains "build failed: message" "$out" "colcon_build failed"
+
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]


### PR DESCRIPTION
## What

A new util for the QA team, called like the other helpers:

```bash
er_update_source_repos <github-pat>     # or: export GITHUB_PAT=... ; er_update_source_repos
```

On the Jetson host it validates the PAT (shape check + live check against the GitHub API), verifies the `er_robot` container is running, injects `bin/update_source_repos.py` into the container, updates every git repo under `/cortex/.catkin_ws/src`, and runs `colcon_build` inside the container when at least one repo updated. On a stripped (non-source) image it exits with a red *"this is not a source code container, the util will not work here"*.

## Per-repo behaviour

| Repo state | Action |
|---|---|
| On a branch, behind origin | fast-forward |
| Uncommitted tracked changes (repo or submodule) | skip + warning — never touches local edits |
| Diverged local commits | skip + warning (`--ff-only`, never rewrites) |
| Update would overwrite an untracked file | skip + warning (other untracked files never block) |
| Branch missing on origin / no `origin` remote | skip + warning |
| Detached HEAD, tip of exactly one origin branch | auto checkout + pull |
| Detached HEAD, on exactly one branch | auto checkout + pull |
| Detached HEAD, on several branches | interactive picker (with skip) |
| Detached HEAD, on no remote branch | skip + warning |
| Submodules | sync + update to the superproject's recorded commits; a stale pointer from an interrupted run self-heals |

Colored summary table at the end; payload exit codes 0 = updated / 10 = nothing to do / 1 = failure drive whether the build runs.

## PAT handling

Classic (`ghp_`, 40 chars) and fine-grained (`github_pat_`) tokens accepted, whitespace stripped. The token never appears in any argv (host or container), remote URL, or git config: the helper function converts the arg to `GITHUB_PAT` env before any process spawns, curl gets it via config-on-stdin from a builtin `printf`, docker via valueless `-e GITHUB_PAT`, and git via a temp `GIT_ASKPASS` helper (with `GIT_TERMINAL_PROMPT=0` so nothing can hang). Public third-party repos never trigger the credential path. Tests assert the PAT is absent from docker and curl argv.

## Tests / CI

`tests/test_update_source_repos.sh`: 89 assertions, no docker or network — the payload runs against real local git fixture repos (`ER_CATKIN_WS` override), the wrapper against fake `docker`/`curl` PATH shims. New `check_update_source_repos.yml` workflow runs shellcheck + `py_compile` + the suite on push. Payload is python3.8/stdlib-only and clean under the pinned flake8/pylint/ruff at line length 140.

## Review

A full code review ran before this PR; all four Important findings were fixed (stale-submodule dirty-gate bug, PAT-in-argv via the helper wiring, untracked-collision misreported as "diverged", missing tip-match test) plus the minor ones. Two judgment calls — **both confirmed by Tom before review**:

1. **Helper wiring deviates from the other `er_*` one-liners** — it passes the PAT via env instead of `"$@"`, because `_fetch_and_call_remote_script` would otherwise hold the token in a ps-visible argv for the whole run.
2. **Partial-failure policy**: any `failed` repo → exit 1 → build skipped, even if other repos updated (per spec). Fine to change if you'd rather build whatever updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
