### PR TITLE
er_jetson_flash: fix apt lock race with apt-daily after clock jump

### DIFF
--- a/bin/er_jetson_flash.py
+++ b/bin/er_jetson_flash.py
@@ -80,6 +80,11 @@ SSH_OPTS = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/nul
 BOOT_TIMEOUT_S = 300
 SSH_TIMEOUT_S = 240
 APT_PROXY_CONF = "/etc/apt/apt.conf.d/99er-usb-proxy"
+# fix_clock() jumps the fresh flash's clock forward by years, which makes
+# systemd's Persistent=true apt-daily timers fire their "missed" runs at once —
+# their apt-get then holds the apt locks exactly when we need them. We stop the
+# timers for this boot and let our own apt-get wait out any run already started.
+APT_LOCK_WAIT_S = 600
 
 USE_COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
 RED = "\033[0;31m" if USE_COLOR else ""
@@ -609,14 +614,19 @@ def fix_clock(target, password):
 
 def apt_install_jetpack(target, password):
     """apt update + install nvidia-jetpack on the Jetson, streaming output."""
+    res = remote_run(target, password,
+                     "systemctl stop apt-daily.timer apt-daily-upgrade.timer", sudo=True)
+    if res.returncode != 0:
+        warn("could not stop apt-daily timers — relying on the apt lock wait")
+    apt_get = "apt-get -o DPkg::Lock::Timeout={}".format(APT_LOCK_WAIT_S)
     print("  apt-get update ...")
-    res = remote_run(target, password, "apt-get update", sudo=True)
+    res = remote_run(target, password, apt_get + " update", sudo=True)
     if res.returncode != 0:
         bad("apt-get update failed:\n{}".format((res.stdout or "").strip()[-2000:]))
         return False
     print("  apt-get install -y nvidia-jetpack  (several GB — this is the long part)...")
     res = remote_run(target, password,
-                     "DEBIAN_FRONTEND=noninteractive apt-get install -y nvidia-jetpack",
+                     "DEBIAN_FRONTEND=noninteractive " + apt_get + " install -y nvidia-jetpack",
                      sudo=True, capture=False)
     if res.returncode != 0:
         bad("nvidia-jetpack install failed (rc {})".format(res.returncode))

--- a/docs/er-jetson-flash.md
+++ b/docs/er-jetson-flash.md
@@ -41,6 +41,12 @@ just takes longer the first time, while the tool walks a guided reinstall.
 5. **Post-flash setup**:
    - waits for the board to boot (USB `0955:7020`) and for ssh
    - fixes the fresh-flash clock skew (apt rejects "future" Release files otherwise)
+   - quiets the apt-daily/unattended-upgrades race: the clock jump makes systemd's
+     persistent apt-daily timers fire "missed" runs immediately, and their apt-get
+     grabs the apt locks (`Could not get lock /var/lib/apt/lists/lock`). The tool
+     stops both timers for this boot only (the shipped image stays stock) and runs
+     its own apt-get with `-o DPkg::Lock::Timeout=600` to wait out any run that
+     already started
    - checks whether the board has internet; when it is USB-only, the tool starts an
      embedded HTTP proxy on the host, reverse-tunnels it over ssh, and points the
      board's apt at it for the duration (config removed afterwards)

--- a/tests/test_er_jetson_flash.py
+++ b/tests/test_er_jetson_flash.py
@@ -179,6 +179,40 @@ class AptProxyConfTest(unittest.TestCase):
         self.assertIn('Acquire::https::Proxy "http://127.0.0.1:12345";', conf)
 
 
+class AptInstallJetpackTest(unittest.TestCase):
+    """fix_clock's jump fires the Persistent apt-daily timers, whose apt-get
+    steals the apt locks (seen in the field: 'Could not get lock
+    /var/lib/apt/lists/lock'). apt_install_jetpack must stop the timers first
+    and make every apt-get wait on the locks instead of failing."""
+
+    def test_stops_timers_then_apt_waits_on_locks(self):
+        commands = []
+
+        def fake_remote_run(_target, _password, command, **_kwargs):
+            commands.append(command)
+            return mock.Mock(returncode=0, stdout="")
+
+        with mock.patch.object(ejf, "remote_run", side_effect=fake_remote_run):
+            self.assertTrue(ejf.apt_install_jetpack("192.0.2.1", "pw"))
+
+        self.assertIn("systemctl stop apt-daily.timer apt-daily-upgrade.timer",
+                      commands[0])
+        apt_cmds = [c for c in commands if "apt-get" in c]
+        self.assertEqual(len(apt_cmds), 2)
+        for cmd in apt_cmds:
+            self.assertIn("-o DPkg::Lock::Timeout={}".format(ejf.APT_LOCK_WAIT_S), cmd)
+        self.assertTrue(apt_cmds[0].endswith(" update"))
+        self.assertIn("install -y nvidia-jetpack", apt_cmds[1])
+
+    def test_timer_stop_failure_does_not_abort(self):
+        def fake_remote_run(_target, _password, command, **_kwargs):
+            returncode = 1 if "systemctl" in command else 0
+            return mock.Mock(returncode=returncode, stdout="")
+
+        with mock.patch.object(ejf, "remote_run", side_effect=fake_remote_run):
+            self.assertTrue(ejf.apt_install_jetpack("192.0.2.1", "pw"))
+
+
 class ProxySmokeTest(unittest.TestCase):
     """start_proxy binds an ephemeral localhost port and accepts connections."""
 


### PR DESCRIPTION
## What happened in the field

First real-world run of `er_jetson_flash` (#47) flashed fine, then post-flash setup died at:

```
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 9202 (apt-get)
```

## Root cause

`fix_clock()` jumps a fresh flash's clock forward by years. Ubuntu's `apt-daily.timer` / `apt-daily-upgrade.timer` are `Persistent=true`, so the jump makes systemd fire their "missed" runs almost immediately — and the internet bridge we just brought up gives them connectivity. Their `apt-get` takes the apt locks in the seconds before our own `apt-get update` runs, which fails fast by default. Classic race; whether you hit it depends on the timers' randomized delay.

## Fix (two layers, nothing killed)

1. `systemctl stop apt-daily.timer apt-daily-upgrade.timer` before touching apt — **stop, not disable/mask**, so it lasts this boot only and the shipped QA image stays stock.
2. Both apt-get calls now run with `-o DPkg::Lock::Timeout=600` (apt ≥1.9.11; focal has 2.0), waiting out any daily job that already started instead of failing. We deliberately don't stop the *services*: SIGTERMing an unattended-upgrades run mid-dpkg is a worse failure mode than waiting.

## Tests

- New `AptInstallJetpackTest`: asserts timers are stopped before any apt-get, both apt-get calls carry the lock wait, and a failed timer-stop degrades to a warning rather than aborting.
- 37/37 unit tests pass; ruff/flake8/pylint clean at CI settings.

Docs updated (`docs/er-jetson-flash.md` post-flash section).
