### PR TITLE
ERD-2135: er_jetson_flash — support boards with no NVMe (eMMC-rootfs flash)

### DIFF
--- a/bin/er_jetson_flash.py
+++ b/bin/er_jetson_flash.py
@@ -6,7 +6,8 @@ Pipeline (subcommand `flash`, the default):
                 (a guided `sdkmanager --cli` reinstall restores it when not — nothing
                 is tied to any particular machine; a fresh machine just takes longer)
   2. preflight— run bin/jetson-flash-preflight.sh: GO / DO NOT FLASH gate
-  3. flash    — sudo ./nvsdkmanager_flash.sh --storage ... --nv-auto-config --username ...
+  3. flash    — sudo ./nvsdkmanager_flash.sh [--storage <dev>] --nv-auto-config --username ...
+                (--storage picks the rootfs device; omitted => rootfs on the internal eMMC)
   4. post     — wait for boot, fix the clock, give the board internet via an
                 embedded HTTP proxy over the USB link when it has none,
                 apt install nvidia-jetpack (pinned 5.1.2-b104), sanity checks
@@ -379,15 +380,53 @@ def current_usb_pid():
     return parse_usb_pid(res.stdout) if res.returncode == 0 else None
 
 
+# nvsdkmanager_flash.sh puts the rootfs on the internal eMMC when given NO
+# --storage, and on an EXTERNAL device (the eMMC then keeps only a boot partition
+# pointing at it) when given one. So an eMMC-rootfs flash means passing no
+# --storage at all — 'internal'/'emmc' therefore resolve to None, not a device
+# name. Boards with no NVMe fitted must flash internal, or the run writes the
+# eMMC boot GPT and then aborts at "Could not stat device /dev/nvme0n1".
+STORAGE_INTERNAL = None
+STORAGE_ALIASES = {"nvme": "nvme0n1p1", "internal": STORAGE_INTERNAL, "emmc": STORAGE_INTERNAL}
+
+
+def resolve_storage(value):
+    """Map a --storage value onto what nvsdkmanager_flash.sh wants.
+
+    Returns a device string (external rootfs) or None (internal eMMC — no
+    --storage flag). Aliases: nvme -> nvme0n1p1, internal/emmc -> None. Any other
+    value (a raw device such as nvme0n1p1 or sda1) passes through unchanged.
+    """
+    key = value.strip().lower()
+    return STORAGE_ALIASES[key] if key in STORAGE_ALIASES else value
+
+
+def flash_command(username, storage):
+    """argv for the nvsdkmanager_flash.sh run. storage=None omits --storage so the
+    rootfs lands on the internal eMMC; a device name puts the rootfs there instead."""
+    cmd = ["sudo", "./nvsdkmanager_flash.sh"]
+    if storage is not None:
+        cmd += ["--storage", storage]
+    return cmd + ["--nv-auto-config", "--username", username]
+
+
 def run_flash(l4t, username, password, storage):
-    """Run nvsdkmanager_flash.sh under sudo, feeding the preseed password on stdin."""
+    """Run nvsdkmanager_flash.sh under sudo, feeding the preseed password on stdin.
+
+    storage is None for an internal-eMMC rootfs (no --storage) or a device name
+    (e.g. nvme0n1p1) for an external rootfs.
+    """
     hdr("== Flash ==")
+    on_nvme = storage is not None and storage.startswith("nvme")
+    print("  rootfs target: {}".format("internal eMMC" if storage is None else storage))
+    if on_nvme:
+        warn("rootfs goes on {} — the board MUST have that NVMe fitted; if it has none, "
+             "Ctrl-C now and re-run with --storage internal".format(storage))
     print("  validating sudo (the flash needs root)...")
     if subprocess.run(["sudo", "-v"], check=False).returncode != 0:
         bad("sudo credentials unavailable")
         return False
-    cmd = ["sudo", "./nvsdkmanager_flash.sh", "--storage", storage,
-           "--nv-auto-config", "--username", username]
+    cmd = flash_command(username, storage)
     print("  running: {}  (in {})".format(" ".join(cmd), l4t))
     print("  expect ~15-25 min; do NOT unplug the board, even on failure it is recoverable\n")
     # nv_preseed.sh reads the new user's password from stdin (`read -s`), so a
@@ -404,6 +443,9 @@ def run_flash(l4t, username, password, storage):
         returncode = proc.wait()
     if returncode != 0:
         bad("flash failed (rc {}) — see {}/initrdlog/ for details".format(returncode, l4t))
+        if on_nvme:
+            warn("no NVMe in this board? that aborts exactly here — re-run with "
+                 "--storage internal to put the rootfs on the eMMC")
         return False
     good("flash reported success")
     return True
@@ -742,7 +784,10 @@ def build_parser():
     flash.add_argument("--password", default=None,
                        help="password for that user (default: $ER_JETSON_PASSWORD, else '{}'). "
                             "Prefer the env var for non-defaults — argv is visible in ps".format(DEF_PASS))
-    flash.add_argument("--storage", default="nvme0n1p1", help="rootfs device (default: %(default)s)")
+    flash.add_argument("--storage", default="nvme0n1p1",
+                       help="rootfs location: 'nvme' (=nvme0n1p1, the default) for an NVMe SSD, "
+                            "'internal' (or 'emmc') for the on-board eMMC on boards with no NVMe, "
+                            "or a raw device such as sda1 (default: %(default)s)")
     flash.add_argument("--yes", action="store_true", help="assume yes on restore prompts (login stays interactive)")
     flash.add_argument("--skip-post", action="store_true", help="stop after the flash itself")
 
@@ -785,7 +830,7 @@ def cmd_flash(args):
         bad("board is not in forced recovery — put it there and re-run (see preflight banner)")
         return EXIT_UNDETERMINED
     password = args.password or os.environ.get("ER_JETSON_PASSWORD") or DEF_PASS
-    if not run_flash(args.l4t, args.username, password, args.storage):
+    if not run_flash(args.l4t, args.username, password, resolve_storage(args.storage)):
         return EXIT_FAILURE
     if args.skip_post:
         good("flash done; post-flash setup skipped (--skip-post)")

--- a/bin/jetson-flash-preflight.sh
+++ b/bin/jetson-flash-preflight.sh
@@ -274,7 +274,7 @@ hdr "== 3. Verdict =="
 case "$module_state:$tree_state" in
     post-pcn:patched)  ok "GO — module needs the patch and the tree has it. Flash away."; exit 0;;
     post-pcn:*)        bad "DO NOT FLASH — this module needs the patch and the tree does NOT have it (see section 2)."; exit 1;;
-    pre-pcn:patched)   ok "GO — pre-PCN module; patched tree lays its eMMC out 64 MiB short (harmless, rootfs is on NVMe)."; exit 0;;
+    pre-pcn:patched)   ok "GO — pre-PCN module; patched tree lays the eMMC 64 MiB short of stock, which still fits and boots a pre-PCN module (whichever device holds the rootfs)."; exit 0;;
     pre-pcn:stock)     ok "GO — pre-PCN module, stock layout fits."; exit 0;;
     pre-pcn:*)         warn "pre-PCN module, but the flash tree is in an unexpected state — fix section 2 first."; exit 2;;
     not-applicable:*)  warn "patch not applicable to the connected device — this script can't vouch for the flash."; exit 2;;

--- a/docs/er-jetson-flash.md
+++ b/docs/er-jetson-flash.md
@@ -7,6 +7,7 @@ sanity-checked QA cortex:
 ```
 er_jetson_flash                      # everything, with extend/extend defaults
 er_jetson_flash --username qa --password s3cret
+er_jetson_flash --storage internal   # board has no NVMe — put the rootfs on the eMMC
 er_jetson_flash verify               # read-only health check of the flash tree
 er_jetson_flash restore              # fix/restore the flash tree, don't flash
 er_jetson_flash make-manifest        # regenerate the canonical manifest (maintainers)
@@ -35,9 +36,14 @@ just takes longer the first time, while the tool walks a guided reinstall.
    Downloads reuse `~/Downloads/nvidia/sdkm_downloads` when present.
 3. **Preflight gate**: runs [`er_jetson_flash_preflight`](jetson-flash-preflight.md);
    anything but GO stops the pipeline.
-4. **Flash**: `sudo ./nvsdkmanager_flash.sh --storage nvme0n1p1 --nv-auto-config
-   --username <user>` — rootfs on NVMe, first-boot user preseeded (no monitor needed).
-   The password is fed to the preseeder over stdin, never argv.
+4. **Flash**: `sudo ./nvsdkmanager_flash.sh [--storage <dev>] --nv-auto-config
+   --username <user>` — first-boot user preseeded (no monitor needed); the password
+   is fed to the preseeder over stdin, never argv. `--storage` chooses where the
+   rootfs goes: the default `nvme0n1p1` puts it on the NVMe SSD (the eMMC then holds
+   only a boot partition pointing at it), while `--storage internal` omits the flag so
+   the rootfs lands on the on-board eMMC. Use `internal` for boards with **no NVMe
+   fitted** — otherwise the flash writes the eMMC boot GPT and then aborts at
+   `Could not stat device /dev/nvme0n1`.
 5. **Post-flash setup**:
    - waits for the board to boot (USB `0955:7020`) and for ssh
    - fixes the fresh-flash clock skew (apt rejects "future" Release files otherwise)
@@ -94,3 +100,6 @@ re-patch and a hand-held flash. This tool makes that whole loop one command.
   are fetched from when not running from a repo checkout (set automatically by
   the `er_jetson_flash` helper function)
 - `--l4t`, `--manifest` — non-default tree / manifest locations
+- `--storage` — rootfs location: `nvme` (default, = `nvme0n1p1`) for an NVMe SSD, or
+  `internal`/`emmc` for the on-board eMMC on boards with no NVMe fitted; also accepts a
+  raw device such as `sda1`. `internal` omits `--storage` from the underlying flash.

--- a/docs/jetson-flash-preflight.md
+++ b/docs/jetson-flash-preflight.md
@@ -89,3 +89,4 @@ Automation can gate on the exit code (`L4T` exported in your shell, same
 default as the script's):
 
     er_jetson_flash_preflight && cd "$L4T" && sudo ./flash.sh jetson-agx-orin-devkit external
+    # swap 'external' for 'internal' to put the rootfs on the eMMC (boards with no NVMe fitted)

--- a/tests/test_er_jetson_flash.py
+++ b/tests/test_er_jetson_flash.py
@@ -380,5 +380,47 @@ class MakeManifestTest(unittest.TestCase):
             self.assertFalse(ejf.make_manifest(l4t, self.output))
 
 
+class StorageSelectionTest(unittest.TestCase):
+    """--storage aliases resolve correctly; flash_command omits --storage for eMMC."""
+
+    def test_nvme_alias_and_passthrough(self):
+        self.assertEqual(ejf.resolve_storage("nvme"), "nvme0n1p1")
+        self.assertEqual(ejf.resolve_storage("nvme0n1p1"), "nvme0n1p1")  # the default passes through
+        self.assertEqual(ejf.resolve_storage("sda1"), "sda1")            # unknown device passes through
+
+    def test_internal_aliases_mean_no_storage_flag(self):
+        # None is the signal to omit --storage, which is how nvsdkmanager_flash.sh
+        # is told to put the rootfs on the internal eMMC.
+        self.assertIsNone(ejf.resolve_storage("internal"))
+        self.assertIsNone(ejf.resolve_storage("emmc"))
+        self.assertIsNone(ejf.resolve_storage("  INTERNAL "))  # trimmed + case-insensitive
+
+    def test_flash_command_external_includes_storage(self):
+        self.assertEqual(
+            ejf.flash_command("qa", "nvme0n1p1"),
+            ["sudo", "./nvsdkmanager_flash.sh", "--storage", "nvme0n1p1",
+             "--nv-auto-config", "--username", "qa"])
+
+    def test_flash_command_internal_omits_storage(self):
+        cmd = ejf.flash_command("qa", None)
+        self.assertEqual(
+            cmd, ["sudo", "./nvsdkmanager_flash.sh", "--nv-auto-config", "--username", "qa"])
+        self.assertNotIn("--storage", cmd)
+
+    def test_cmd_flash_passes_resolved_storage_to_run_flash(self):
+        # end-to-end wiring: `--storage internal` must reach run_flash as None (eMMC),
+        # with every hardware/tree gate stubbed out.
+        args = ejf.build_parser().parse_args(["flash", "--storage", "internal", "--skip-post"])
+        with mock.patch.object(ejf, "check_host_tools", return_value=True), \
+             mock.patch.object(ejf, "load_canonical_manifest", return_value=None), \
+             mock.patch.object(ejf, "ensure_tree", return_value=True), \
+             mock.patch.object(ejf, "run_preflight", return_value=ejf.EXIT_OK), \
+             mock.patch.object(ejf, "current_usb_pid", return_value=ejf.USB_PID_RECOVERY), \
+             mock.patch.object(ejf, "run_flash", return_value=True) as run_flash:
+            self.assertEqual(ejf.cmd_flash(args), ejf.EXIT_OK)
+        # run_flash(l4t, username, password, storage) — storage is the 4th positional arg
+        self.assertIsNone(run_flash.call_args[0][3])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

`er_jetson_flash` hardcoded the flash to `nvsdkmanager_flash.sh --storage nvme0n1p1`, i.e. rootfs on NVMe. On an AGX Orin with **no NVMe fitted**, the run writes the eMMC boot GPT fine and then aborts partway through the initrd stage:

```
Successfully create gpt for emmc
Starting to create gpt for external device
Could not stat device /dev/nvme0n1
Flash failure
```

Both flash utils assumed every board has an NVMe (`jetson-flash-preflight.sh`'s GO verdict even asserted "rootfs is on NVMe"). This PR makes the pipeline flash boards with **and** without NVMe.

## Root cause / mechanism

Confirmed by reading `nvsdkmanager_flash.sh` in the deployment tree:

- `--storage` only accepts `nvme0n1p1` or `sda1`; anything else (incl. `mmcblk0p1`) is rejected as *"Invalid storage device"*. With `--storage`, it runs the initrd **external-device** flash — the path that dies when the NVMe is absent.
- With **no `--storage`**, it falls through to `nvautoflash.sh` → the standard **internal eMMC** flash, and `--username` still preseeds the first-boot user over stdin.

So an eMMC-rootfs flash = **omit `--storage` entirely** (not a device name).

## Changes

- **`bin/er_jetson_flash.py`**
  - `--storage` now accepts aliases: `nvme` (=`nvme0n1p1`, the default — **behaviour unchanged** for existing NVMe QA-cortex flows) and `internal`/`emmc` (→ omit `--storage` → rootfs on eMMC). Raw device names still pass through.
  - New pure, unit-tested helpers `resolve_storage()` and `flash_command()`.
  - `run_flash` warns up front when targeting NVMe, and on failure points at `--storage internal`.
- **`bin/jetson-flash-preflight.sh`** — GO verdict no longer asserts NVMe; storage-neutral wording.
- **`docs/er-jetson-flash.md`, `docs/jetson-flash-preflight.md`** — document `--storage` and the no-NVMe (eMMC) path.
- **`tests/test_er_jetson_flash.py`** — cover alias resolution, `flash_command` with/without `--storage`, and the `cmd_flash` → `run_flash` wiring. **42/42 pass**; flake8 + pylint clean.

## Usage

```bash
er_jetson_flash                    # NVMe rootfs (unchanged default)
er_jetson_flash --storage internal # eMMC rootfs — boards with no NVMe
```

## Verification

- Script-level behaviour **verified against `nvsdkmanager_flash.sh` in the deployment tree** (`deployment@…`): omit-`--storage` → `nvautoflash.sh` internal eMMC, `--username` preseed over stdin intact, `mmcblk0p1` rejected.
- Unit tests + linters green.
- ⚠️ **Not yet flash-tested on real hardware** — please flash a genuine no-NVMe AGX Orin end-to-end (`er_jetson_flash --storage internal`) before merging. That's the one thing I can't do from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)