### PR TITLE
Add cortex_ws_info: spec-vs-actual table for workspace repos (ERD-2162 WP0)

### DIFF
--- a/.github/workflows/check_cortex_ws_info.yml
+++ b/.github/workflows/check_cortex_ws_info.yml
@@ -1,0 +1,29 @@
+name: Check cortex_ws_info
+
+on: [push]
+
+jobs:
+  check_cortex_ws_info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v4
+
+      # the payload runs inside the 20.04 images' Python 3.8 —
+      # test on that, not on whatever ubuntu-latest ships
+      - name: set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+
+      - name: install PyYAML
+        shell: bash
+        run: python3 -m pip install pyyaml
+
+      - name: python syntax check payload
+        shell: bash
+        run: python3 -m py_compile bin/cortex_ws_info.py
+
+      - name: run cortex_ws_info tests
+        shell: bash
+        run: python3 tests/test_cortex_ws_info.py

--- a/.helper_bash_functions
+++ b/.helper_bash_functions
@@ -247,6 +247,10 @@ er_jetson_flash_preflight() { _fetch_and_call_remote_script "bin/jetson-flash-pr
 er_jetson_flash() { _fetch_and_call_remote_script_with python3 "bin/er_jetson_flash.py" "$@"; }
 # PAT converted to env before any process spawns, so it never appears in argv/ps.
 er_update_source_repos() { GITHUB_PAT="${1:-${GITHUB_PAT:-}}" _fetch_and_call_remote_script "bin/update-source-repos.sh"; }
+# Spec-vs-actual table per workspace repo: declared branch and as-built SHA from
+# the provenance files baked into the image, current HEAD and dirty from git.
+# Replaces `wstool info` on the ros1/ros2/bridge workspaces (all colcon).
+cortex_ws_info() { _fetch_and_call_remote_script_with python3 "bin/cortex_ws_info.py" "$@"; }
 
 # python linters
 LINTER_VERSIONS_URL="https://raw.githubusercontent.com/Extend-Robotics/er_build_tools/refs/heads/${THIS_SCRIPT_BRANCH}/linter_versions.env"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ update_helper_bash_functions
 Below are links to further docs on specific tools, but there are pleanty more undocumented functions [in the helper file](.helper_bash_functions)
 
 - [update_source_repos](docs/update-source-repos.md) - Takes your gh PAT, pulls any source code updates inside your new arch container and then rebuilds your workspace
+- [cortex_ws_info](docs/cortex-ws-info.md) - per-repo spec-vs-actual table for the cortex colcon workspaces (ros1/ros2/bridge): local-name | declared branch | as-built SHA | current HEAD | dirty, combining the provenance files baked into the image with live git (`n/a (<why>)` when a file isn't baked). Runs in cortex containers and on dev hosts; replaces the spec-vs-actual view `wstool info` used to provide.
 - [usb-camera-healthcheck](docs/usb-camera-healthcheck.md) - report USB link speed + verdict for every UVC camera (sysfs only, no root, curl-bash).
 - [jetson-flash-preflight](docs/jetson-flash-preflight.md) - GO / DO NOT FLASH pre-flash check for the AGX Orin 64GB eMMC patch (PCN210100): module detection over USB + flash-tree patch check (curl-bash).
 - [er_jetson_flash](docs/er-jetson-flash.md) - one-command AGX Orin QA-cortex flash: verify the JetPack 5.1.2 tree against a canonical manifest (guided sdkmanager reinstall when broken), preflight gate, flash to NVMe, then post-flash setup (clock, apt over the USB link when offline, nvidia-jetpack, sanity checks).

--- a/bin/cortex_ws_info.py
+++ b/bin/cortex_ws_info.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Per-repo spec-vs-actual table for the colcon workspaces in a cortex image.
+
+For every repo in each workspace, prints:
+    local-name | declared branch | as-built SHA | current HEAD | dirty
+
+The declared branch and as-built SHA come from provenance files baked into the
+image at build time; the current HEAD and dirty state come from git. A missing
+provenance file is reported per-cell as "n/a (<why>)" — images built before the
+provenance convention landed (ERD-2141 phase B) simply have fewer files baked.
+
+Provenance files, looked up per workspace root:
+  - <workspace>/build_manifest.repos   resolved closure manifest: the exact SHA
+                                       every repo was built from (.repos map
+                                       format; baked from ERD-2141 phase B on)
+  - <workspace>/build_branches.yaml    branch record: the branch each repo was
+                                       pinned from, with /cortex/rosinstall_branches.yaml
+                                       as the image-wide fallback that pre-phase-B
+                                       images bake (wstool-list or .repos map shape)
+
+Repos in a provenance record whose source is not on disk (DELETE_SRC release
+images) still get a row, with the git-derived columns marked n/a.
+
+Usage: cortex_ws_info.py [workspace_dir ...]
+       (no args: every default workspace that exists on this machine)
+"""
+import os
+import subprocess
+import sys
+
+DEFAULT_WORKSPACES = [
+    "/cortex/.catkin_ws",  # ros1 workspace (legacy path name; it is a colcon workspace)
+    "/cortex/ros2_ws",
+    "/cortex/ros2_ros1_bridge_ws",
+]
+IMAGE_WIDE_BRANCH_RECORD = "/cortex/rosinstall_branches.yaml"
+SHA_DISPLAY_LENGTH = 12
+COLUMN_HEADERS = ["local-name", "declared branch", "as-built SHA", "current HEAD", "dirty"]
+
+
+def load_yaml(path):
+    try:
+        import yaml
+    except ImportError:
+        sys.exit("ERROR: PyYAML is required to read provenance records (apt install python3-yaml)")
+    with open(path, encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def entries_from_record(parsed, path):
+    """{local-name: version} from either provenance shape.
+
+    Accepts the .repos map shape ({repositories: {name: {version: ...}}}) and
+    the wstool-list shape ([{git: {local-name: ..., version: ...}}]) that
+    pre-ERD-2162 images bake as their branch record.
+    """
+    if isinstance(parsed, dict) and isinstance(parsed.get("repositories"), dict):
+        return {name: str(spec.get("version", ""))
+                for name, spec in parsed["repositories"].items()}
+    if isinstance(parsed, list):
+        entries = {}
+        for item in parsed:
+            if not (isinstance(item, dict) and isinstance(item.get("git"), dict)):
+                raise ValueError(f"{path}: unrecognised entry {item!r}")
+            spec = item["git"]
+            entries[str(spec["local-name"])] = str(spec.get("version", ""))
+        return entries
+    raise ValueError(f"{path}: unrecognised provenance record shape")
+
+
+def find_branch_record(workspace_dir):
+    """(entries, reason): the branch record covering this workspace, else why not."""
+    for path in [os.path.join(workspace_dir, "build_branches.yaml"), IMAGE_WIDE_BRANCH_RECORD]:
+        if os.path.isfile(path):
+            return entries_from_record(load_yaml(path), path), None
+    return {}, "no branch record baked"
+
+
+def find_build_manifest(workspace_dir):
+    """(entries, reason): the as-built closure manifest, else why not."""
+    path = os.path.join(workspace_dir, "build_manifest.repos")
+    if os.path.isfile(path):
+        return entries_from_record(load_yaml(path), path), None
+    return {}, "no build manifest baked (pre-ERD-2141-phase-B image)"
+
+
+def repos_on_disk(workspace_dir):
+    """{local-name: repo_dir} for every git checkout directly under the
+    workspace root or its src/ (unitree_sdk2_python lives outside src/)."""
+    repos = {}
+    source_dir = os.path.join(workspace_dir, "src")
+    for parent, prefix in [(workspace_dir, ""), (source_dir, "src/")]:
+        if not os.path.isdir(parent):
+            continue
+        for name in sorted(os.listdir(parent)):
+            repo_dir = os.path.join(parent, name)
+            if os.path.isdir(os.path.join(repo_dir, ".git")):
+                repos[prefix + name if prefix and name in repos else name] = repo_dir
+    return repos
+
+
+def git_output(repo_dir, *arguments):
+    result = subprocess.run(
+        ["git", "-C", repo_dir, *arguments],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, text=True)
+    return result.stdout.strip()
+
+
+def head_and_dirty(repo_dir):
+    head_sha = git_output(repo_dir, "rev-parse", f"--short={SHA_DISPLAY_LENGTH}", "HEAD")
+    branch_probe = subprocess.run(
+        ["git", "-C", repo_dir, "symbolic-ref", "-q", "--short", "HEAD"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+    head = head_sha if branch_probe.returncode else f"{head_sha} ({branch_probe.stdout.strip()})"
+    dirty = "yes" if git_output(repo_dir, "status", "--porcelain") else "no"
+    return head, dirty
+
+
+def not_available(reason):
+    return f"n/a ({reason})"
+
+
+def workspace_rows(workspace_dir):
+    branch_entries, branch_reason = find_branch_record(workspace_dir)
+    manifest_entries, manifest_reason = find_build_manifest(workspace_dir)
+    disk_repos = repos_on_disk(workspace_dir)
+    local_names = sorted(set(disk_repos) | set(branch_entries) | set(manifest_entries))
+    if not local_names:
+        return []
+
+    rows = []
+    for name in local_names:
+        declared = branch_entries.get(name) or not_available(
+            branch_reason or "not in branch record")
+        as_built = manifest_entries.get(name) or not_available(
+            manifest_reason or "not in build manifest")
+        as_built = as_built if as_built.startswith("n/a") else as_built[:SHA_DISPLAY_LENGTH]
+        if name in disk_repos:
+            head, dirty = head_and_dirty(disk_repos[name])
+        else:
+            head = dirty = not_available("source not on disk")
+        rows.append([name, declared, as_built, head, dirty])
+    return rows
+
+
+def format_table(rows):
+    widths = [max(len(row[column]) for row in [COLUMN_HEADERS] + rows)
+              for column in range(len(COLUMN_HEADERS))]
+    lines = []
+    for row in [COLUMN_HEADERS] + rows:
+        lines.append(" | ".join(cell.ljust(width) for cell, width in zip(row, widths)).rstrip())
+    lines.insert(1, "-+-".join("-" * width for width in widths))
+    return "\n".join(lines)
+
+
+def main(argv):
+    if len(argv) > 1:
+        workspaces = argv[1:]
+        for workspace_dir in workspaces:
+            if not os.path.isdir(workspace_dir):
+                sys.exit(f"ERROR: workspace directory not found: {workspace_dir}")
+    else:
+        workspaces = [path for path in DEFAULT_WORKSPACES if os.path.isdir(path)]
+        if not workspaces:
+            sys.exit("ERROR: none of the default workspaces exist here: "
+                     + ", ".join(DEFAULT_WORKSPACES)
+                     + " — pass a workspace directory explicitly")
+
+    for workspace_dir in workspaces:
+        print(f"\n{workspace_dir}:")
+        rows = workspace_rows(workspace_dir)
+        if rows:
+            print(format_table(rows))
+        else:
+            print("  no repos on disk and no provenance records for this workspace")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/docs/cortex-ws-info.md
+++ b/docs/cortex-ws-info.md
@@ -1,0 +1,58 @@
+# cortex_ws_info
+
+Per-repo spec-vs-actual table for the colcon workspaces in a cortex image:
+the declared branch and as-built SHA come from provenance files baked into the
+image at build time, the current HEAD and dirty state from live git. Replaces
+the spec-vs-actual view `wstool info` used to provide, and covers all three
+workspaces — ros1 (`/cortex/.catkin_ws` is a legacy path name for a colcon
+workspace), ros2 and the ros1/ros2 bridge. Works inside cortex containers and
+on dev hosts.
+
+## Run it
+
+With the helper functions sourced:
+
+    cortex_ws_info                     # every default workspace that exists
+    cortex_ws_info /cortex/ros2_ws     # or explicit workspace dir(s)
+
+Default workspaces: `/cortex/.catkin_ws`, `/cortex/ros2_ws`,
+`/cortex/ros2_ros1_bridge_ws`.
+
+## Columns
+
+| Column | Source |
+|--------|--------|
+| `local-name` | union of repos on disk and repos in the provenance records |
+| `declared branch` | branch record (lookup below) |
+| `as-built SHA` | `<workspace>/build_manifest.repos`, shown as 12 chars |
+| `current HEAD` | `git rev-parse` (branch name appended when on one) |
+| `dirty` | `git status --porcelain` |
+
+A cell whose source is unavailable prints `n/a (<why>)` rather than guessing:
+images built before the provenance convention landed (ERD-2141 phase B) bake
+fewer files, and stripped release images (no `src/`) still get a row per
+provenance repo with the git-derived columns marked n/a.
+
+## Provenance file lookup, per workspace
+
+1. `<workspace>/build_manifest.repos` — resolved closure manifest: the exact
+   SHA every repo was built from (as-built SHA column)
+2. `<workspace>/build_branches.yaml` — the branch each repo was pinned from
+   (declared branch column)
+3. `/cortex/rosinstall_branches.yaml` — image-wide branch-record fallback,
+   the only record pre-phase-B images bake
+
+## Example output
+
+    /cortex/ros2_ws:
+    local-name   | declared branch | as-built SHA | current HEAD        | dirty
+    -------------+-----------------+--------------+---------------------+------
+    er_common    | main            | 1a2b3c4d5e6f | 1a2b3c4d5e6f (main) | no
+    er_interface | ERD-2100_grasp  | 9f8e7d6c5b4a | 0123456789ab (main) | yes
+
+## Exit behaviour
+
+Exits non-zero with a clear error when an explicitly passed workspace
+directory does not exist, none of the default workspaces exist on the machine,
+PyYAML is missing, or a provenance record cannot be parsed. Otherwise exits 0,
+including when some cells are `n/a`.

--- a/tests/test_cortex_ws_info.py
+++ b/tests/test_cortex_ws_info.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Self-contained tests for bin/cortex_ws_info.py — tmpdir git repos, no network.
+
+Run with:
+    python3 -m unittest tests.test_cortex_ws_info        (from the repo root)
+    python3 tests/test_cortex_ws_info.py
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir, "bin"))
+import cortex_ws_info as cwi  # noqa: E402  (path bootstrap must run first)
+
+WSTOOL_SHAPE_RECORD = """\
+- git:
+    local-name: repo_a
+    uri: https://github.com/Extend-Robotics/repo_a
+    version: main
+- git:
+    local-name: repo_gone
+    uri: https://github.com/Extend-Robotics/repo_gone
+    version: feature/xyz
+"""
+
+REPOS_MAP_SHAPE_RECORD = """\
+repositories:
+  repo_a:
+    type: git
+    url: https://github.com/Extend-Robotics/repo_a
+    version: 0123456789abcdef0123456789abcdef01234567
+"""
+
+
+def make_git_repo(parent_dir, name):
+    repo_dir = os.path.join(parent_dir, name)
+    os.makedirs(repo_dir)
+    subprocess.run(["git", "init", "--quiet", repo_dir], check=True)
+    with open(os.path.join(repo_dir, "file.txt"), "w", encoding="utf-8") as handle:
+        handle.write("content\n")
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "-C", repo_dir, "add", "."], check=True, env=env)
+    subprocess.run(["git", "-C", repo_dir, "commit", "--quiet", "-m", "initial"],
+                   check=True, env=env)
+    return repo_dir
+
+
+class EntriesFromRecordTest(unittest.TestCase):
+    def test_wstool_list_shape(self):
+        import yaml
+        entries = cwi.entries_from_record(yaml.safe_load(WSTOOL_SHAPE_RECORD), "record")
+        self.assertEqual(entries, {"repo_a": "main", "repo_gone": "feature/xyz"})
+
+    def test_repos_map_shape(self):
+        import yaml
+        entries = cwi.entries_from_record(yaml.safe_load(REPOS_MAP_SHAPE_RECORD), "record")
+        self.assertEqual(entries, {"repo_a": "0123456789abcdef0123456789abcdef01234567"})
+
+    def test_unrecognised_shape_raises(self):
+        with self.assertRaises(ValueError):
+            cwi.entries_from_record("just a string", "record")
+        with self.assertRaises(ValueError):
+            cwi.entries_from_record([{"hg": {"local-name": "x"}}], "record")
+
+
+class WorkspaceRowsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.workspace = os.path.join(self.tmp, "ws")
+        os.makedirs(os.path.join(self.workspace, "src"))
+        self.no_fallback = mock.patch.object(
+            cwi, "IMAGE_WIDE_BRANCH_RECORD",
+            os.path.join(self.tmp, "nonexistent.yaml"))
+        self.no_fallback.start()
+        self.addCleanup(self.no_fallback.stop)
+
+    def write_branch_record(self, text):
+        with open(os.path.join(self.workspace, "build_branches.yaml"), "w",
+                  encoding="utf-8") as handle:
+            handle.write(text)
+
+    def rows_by_name(self):
+        return {row[0]: row for row in cwi.workspace_rows(self.workspace)}
+
+    def test_no_provenance_files_gives_explicit_reasons(self):
+        make_git_repo(os.path.join(self.workspace, "src"), "repo_a")
+        row = self.rows_by_name()["repo_a"]
+        self.assertEqual(row[1], "n/a (no branch record baked)")
+        self.assertEqual(row[2], "n/a (no build manifest baked (pre-ERD-2141-phase-B image))")
+        self.assertNotIn("n/a", row[3])
+        self.assertEqual(row[4], "no")
+
+    def test_declared_branch_read_from_workspace_record(self):
+        make_git_repo(os.path.join(self.workspace, "src"), "repo_a")
+        self.write_branch_record(WSTOOL_SHAPE_RECORD)
+        self.assertEqual(self.rows_by_name()["repo_a"][1], "main")
+
+    def test_record_entry_without_source_on_disk_still_gets_a_row(self):
+        self.write_branch_record(WSTOOL_SHAPE_RECORD)
+        row = self.rows_by_name()["repo_gone"]
+        self.assertEqual(row[1], "feature/xyz")
+        self.assertEqual(row[3], "n/a (source not on disk)")
+        self.assertEqual(row[4], "n/a (source not on disk)")
+
+    def test_dirty_repo_reported(self):
+        repo_dir = make_git_repo(os.path.join(self.workspace, "src"), "repo_a")
+        with open(os.path.join(repo_dir, "file.txt"), "a", encoding="utf-8") as handle:
+            handle.write("local edit\n")
+        self.assertEqual(self.rows_by_name()["repo_a"][4], "yes")
+
+    def test_as_built_sha_from_build_manifest(self):
+        make_git_repo(os.path.join(self.workspace, "src"), "repo_a")
+        with open(os.path.join(self.workspace, "build_manifest.repos"), "w",
+                  encoding="utf-8") as handle:
+            handle.write(REPOS_MAP_SHAPE_RECORD)
+        self.assertEqual(self.rows_by_name()["repo_a"][2],
+                         "0123456789abcdef0123456789abcdef01234567"[:cwi.SHA_DISPLAY_LENGTH])
+
+    def test_repo_outside_src_is_found(self):
+        make_git_repo(self.workspace, "unitree_sdk2_python")
+        self.assertIn("unitree_sdk2_python", self.rows_by_name())
+
+
+class MainTest(unittest.TestCase):
+    def test_explicit_missing_workspace_fails(self):
+        with self.assertRaises(SystemExit):
+            cwi.main(["cortex_ws_info.py", "/nonexistent/workspace"])
+
+    def test_no_default_workspace_fails(self):
+        with mock.patch.object(cwi, "DEFAULT_WORKSPACES", ["/nonexistent/ws"]):
+            with self.assertRaises(SystemExit):
+                cwi.main(["cortex_ws_info.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`cortex_ws_info` in `.helper_bash_functions` prints, per workspace repo:

```
local-name | declared branch | as-built SHA | current HEAD | dirty
```

- **declared branch** and **as-built SHA** come from provenance files baked into the image (`<ws>/build_branches.yaml` / `<ws>/build_manifest.repos`, with `/cortex/rosinstall_branches.yaml` as the fallback today's images bake). A missing file gives an explicit `n/a (<why>)` — pre-ERD-2141-phase-B images degrade legibly, and phase B's provenance baking targets this contract.
- **current HEAD** and **dirty** come from git.
- Works identically on the ros1/ros2/bridge workspaces (all colcon), both distros, and dev hosts; repos outside `src/` (e.g. `unitree_sdk2_python`) are found too.

This is the uniform replacement for `wstool info`'s spec-vs-actual table and must land before ERD-2162 removes wstool from the images.

## Testing

- 11 unit tests (`tests/test_cortex_ws_info.py`, tmpdir git fixtures, no network) + new `check_cortex_ws_info.yml` CI running them on Python 3.8.
- Exercised on a dev host against a running 20.04 cortex container: real git columns, explicit `n/a (no branch record baked)` / `n/a (no build manifest baked …)` provenance columns, root-level vs `src/` name collision handled.
- pylint/flake8/ruff clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)